### PR TITLE
chore: add build-source-image during pipeline runs

### DIFF
--- a/.tekton/tuftool-pull-request.yaml
+++ b/.tekton/tuftool-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile.rh
+  - name: build-source-image
+    value: true
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/tuftool-push.yaml
+++ b/.tekton/tuftool-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/securesign/cli-tuftool:{{revision}}
   - name: dockerfile
     value: Dockerfile.rh
+  - name: build-source-image
+    value: true
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
Ensures that a source image is built -- a requirement for downstream releases.

Unfortunately, cachi2 does not support rust, so we'll need to get an exception for hermetic builds.

/cc @fghanmi 