### PR TITLE
implementing tuf compliant folder structure | SECURESIGN-1337

### DIFF
--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -93,7 +93,7 @@ tuftool create \
   --outdir "${WRK}/tuf-repo"
 
 # you can see our signed repository's metadata here:
-ls "${WRK}/tuf-repo/metadata"
+ls "${WRK}/tuf-repo/"
 # and you can see our signed repository's targets here:
 ls "${WRK}/tuf-repo/targets"
 
@@ -114,7 +114,7 @@ tuftool update \
    --timestamp-expires 'in 1 week' \
    --timestamp-version 2 \
    --outdir "${WRK}/tuf-repo" \
-   --metadata-url file:///$WRK/tuf-repo/metadata
+   --metadata-url file:///$WRK/tuf-repo
 
 #[Optional] Set an RHTAS target (fulcio, ctlog, rekor, tsa)!
 touch "${WRK}/input/ctfe.pub" 
@@ -131,7 +131,7 @@ tuftool rhtas \
    --timestamp-expires 'in 1 week' \
    --timestamp-version 3 \
    --outdir "${WRK}/tuf-repo" \
-   --metadata-url file:///$WRK/tuf-repo/metadata
+   --metadata-url file:///$WRK/tuf-repo/
 
 # delete a target
 tuftool rhtas \
@@ -145,8 +145,7 @@ tuftool rhtas \
    --timestamp-expires 'in 1 week' \
    --timestamp-version 4 \
    --outdir "${WRK}/tuf-repo" \
-   --metadata-url file:///$WRK/tuf-repo/metadata
-
+   --metadata-url file:///$WRK/tuf-repo/
 ```
 
 
@@ -159,10 +158,10 @@ for this example we will use a file based url to download from local repo.
 ```sh
 # download tuf repo
 tuftool download \
-   --root "${ROOT}" \
+   --root "${WRK}/tuf-repo/root.json" \
    -t "file://${WRK}/tuf-repo/targets" \
-   -m "file://${WRK}/tuf-repo/metadata" \
-   "${WRK}/tuf-downlaod"
+   -m "file://${WRK}/tuf-repo/" \
+   "${WRK}/tuf-download"
 ```
 
 ## HTTP Proxy Support

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -96,9 +96,8 @@ impl AddKeyArgs {
             .sign(&keys)
             .await
             .context(error::SignRepoSnafu)?;
-        let metadata_destination_out = &self.outdir.join("metadata");
         updated_role
-            .write(metadata_destination_out, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [role.to_string()].to_vec(),

--- a/tuftool/src/add_role.rs
+++ b/tuftool/src/add_role.rs
@@ -140,9 +140,8 @@ impl AddRoleArgs {
             .sign(&keys)
             .await
             .context(error::SignRepoSnafu)?;
-        let metadata_destination_out = &self.outdir.join("metadata");
         updated_role
-            .write(metadata_destination_out, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [self.delegatee.clone(), role.to_string()].to_vec(),
@@ -220,9 +219,8 @@ impl AddRoleArgs {
             .timestamp_expires(timestamp_expires);
 
         let signed_repo = editor.sign(&keys).await.context(error::SignRepoSnafu)?;
-        let metadata_destination_out = &self.outdir.join("metadata");
         signed_repo
-            .write(metadata_destination_out)
+            .write(&self.outdir)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [self.delegatee.clone(), role.to_string()].to_vec(),

--- a/tuftool/src/create_role.rs
+++ b/tuftool/src/create_role.rs
@@ -54,9 +54,8 @@ impl CreateRoleArgs {
             .await
             .context(error::SignRepoSnafu)?;
         // write the new role
-        let metadata_destination_out = &self.outdir.join("metadata");
         new_role
-            .write(metadata_destination_out, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [role.to_string()].to_vec(),

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -77,9 +77,8 @@ impl RemoveKeyArgs {
             .sign(&keys)
             .await
             .context(error::SignRepoSnafu)?;
-        let metadata_destination_out = &self.outdir.join("metadata");
         updated_role
-            .write(metadata_destination_out, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [role.to_string()].to_vec(),

--- a/tuftool/src/remove_role.rs
+++ b/tuftool/src/remove_role.rs
@@ -76,9 +76,8 @@ impl RemoveRoleArgs {
             .sign(&keys)
             .await
             .context(error::SignRepoSnafu)?;
-        let metadata_destination_out = &self.outdir.join("metadata");
         updated_role
-            .write(metadata_destination_out, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRolesSnafu {
                 roles: [role.to_string()].to_vec(),

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -271,12 +271,11 @@ impl RhtasArgs {
                     outdir: targets_outdir,
                 })?;
         }
-        let metadata_dir = &self.outdir.join("metadata");
         signed_repo
-            .write(metadata_dir)
+            .write(&self.outdir)
             .await
             .context(error::WriteRepoSnafu {
-                directory: metadata_dir,
+                directory: &self.outdir,
             })?;
 
         Ok(())

--- a/tuftool/src/transfer_metadata.rs
+++ b/tuftool/src/transfer_metadata.rs
@@ -134,12 +134,11 @@ impl TransferMetadataArgs {
 
         let signed_repo = editor.sign(&keys).await.context(error::SignRepoSnafu)?;
 
-        let metadata_dir = &self.outdir.join("metadata");
         signed_repo
-            .write(metadata_dir)
+            .write(&self.outdir)
             .await
             .context(error::WriteRepoSnafu {
-                directory: metadata_dir,
+                directory: &self.outdir,
             })?;
 
         Ok(())

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -9,6 +9,7 @@ use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use snafu::{OptionExt, ResultExt};
+use std::fs;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use tough::editor::signed::PathExists;
@@ -209,13 +210,15 @@ impl UpdateArgs {
         };
 
         // Write the metadata to the outdir
-        let metadata_dir = &self.outdir.join("metadata");
         signed_repo
-            .write(metadata_dir)
+            .write(&self.outdir)
             .await
             .context(error::WriteRepoSnafu {
-                directory: metadata_dir,
+                directory: &self.outdir,
             })?;
+
+        let root_path = &self.outdir.join("root.json");
+        let _ = fs::copy(&self.root, root_path);
 
         Ok(())
     }

--- a/tuftool/src/update_targets.rs
+++ b/tuftool/src/update_targets.rs
@@ -121,12 +121,11 @@ impl UpdateTargetsArgs {
         };
 
         // Write the metadata to the outdir
-        let metadata_dir = &self.outdir.join("metadata");
         signed_role
-            .write(metadata_dir, false)
+            .write(&self.outdir, false)
             .await
             .context(error::WriteRepoSnafu {
-                directory: metadata_dir,
+                directory: &self.outdir,
             })?;
 
         Ok(())

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -58,7 +58,7 @@ async fn create_command() {
     // Load our newly created repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(repo_dir.path().join("metadata")),
+        dir_url(repo_dir.path()),
         dir_url(repo_dir.path().join("targets")),
     )
     .load()

--- a/tuftool/tests/delegation_commands.rs
+++ b/tuftool/tests/delegation_commands.rs
@@ -77,7 +77,7 @@ async fn create_add_role_command() {
 
     // Set new expiration date for the new role
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -112,7 +112,7 @@ async fn create_add_role_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -141,7 +141,7 @@ async fn create_add_role_command() {
         .success();
 
     // Load the updated repo
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
     let updated_targets_base_url = &dir_url(new_repo_dir.path().join("targets"));
     let repo = RepositoryLoader::new(
         &tokio::fs::read(&root_json).await.unwrap(),
@@ -187,7 +187,7 @@ async fn create_add_role_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -238,7 +238,7 @@ async fn create_add_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path()).as_str(),
         ])
         .assert()
         .success();
@@ -246,7 +246,7 @@ async fn create_add_role_command() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -275,7 +275,7 @@ async fn update_target_command() {
 
     // Set new expiration date for the new role
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -310,7 +310,7 @@ async fn update_target_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -340,9 +340,9 @@ async fn update_target_command() {
 
     // Update A's targets
     let ut_out = TempDir::new().unwrap();
-    let meta_out_url = dir_url(ut_out.path().join("metadata"));
+    let meta_out_url = dir_url(ut_out.path());
     let targets_out_url = ut_out.path().join("targets");
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
     let targets_input_dir = test_utils::test_data().join("targets");
     Command::cargo_bin("tuftool")
         .unwrap()
@@ -418,7 +418,7 @@ async fn update_target_command() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -452,7 +452,7 @@ async fn add_key_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -487,7 +487,7 @@ async fn add_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -514,7 +514,7 @@ async fn add_key_command() {
         ])
         .assert()
         .success();
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
 
     // add key to A
     let key_out = TempDir::new().unwrap();
@@ -556,7 +556,7 @@ async fn add_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(key_out.path().join("metadata")).as_str(),
+            dir_url(key_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -579,7 +579,7 @@ async fn add_key_command() {
         .assert()
         .success();
 
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
 
     let create_out = TempDir::new().unwrap();
     // create role B
@@ -614,7 +614,7 @@ async fn add_key_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key1.to_str().unwrap(),
             "--root",
@@ -665,7 +665,7 @@ async fn add_key_command() {
             "--role",
             "A",
             "-i",
-            dir_url(add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path()).as_str(),
         ])
         .assert()
         .success();
@@ -673,7 +673,7 @@ async fn add_key_command() {
     // Load the updated repo
     let _repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -700,7 +700,7 @@ fn remove_key_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -737,7 +737,7 @@ fn remove_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -765,7 +765,7 @@ fn remove_key_command() {
         .assert()
         .success();
 
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
 
     // remove key from A
     let key_out = TempDir::new().unwrap();
@@ -807,7 +807,7 @@ fn remove_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(key_out.path().join("metadata")).as_str(),
+            dir_url(key_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -830,7 +830,7 @@ fn remove_key_command() {
         .assert()
         .success();
 
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
 
     let create_out = TempDir::new().unwrap();
     // create role B
@@ -865,7 +865,7 @@ fn remove_key_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key1.to_str().unwrap(),
             "--root",
@@ -903,7 +903,7 @@ async fn remove_role_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -938,7 +938,7 @@ async fn remove_role_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -967,7 +967,7 @@ async fn remove_role_command() {
         .success();
 
     // Load the updated repo
-    let updated_metadata_base_url = dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = dir_url(new_repo_dir.path());
     let updated_targets_base_url = dir_url(new_repo_dir.path().join("targets"));
     let repo = RepositoryLoader::new(
         &tokio::fs::read(&root_json).await.unwrap(),
@@ -1013,7 +1013,7 @@ async fn remove_role_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1070,14 +1070,14 @@ async fn remove_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path()).as_str(),
         ])
         .assert()
         .success();
 
     // Remove B from the repo
     let remove_b_out = TempDir::new().unwrap();
-    let updated_metadata_base_url = &dir_url(update_out.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(update_out.path());
 
     // remove role B from A metadata and sign A meta
     Command::cargo_bin("tuftool")
@@ -1143,7 +1143,7 @@ async fn remove_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(remove_b_out.path().join("metadata")).as_str(),
+            dir_url(remove_b_out.path()).as_str(),
         ])
         .assert()
         .success();
@@ -1151,7 +1151,7 @@ async fn remove_role_command() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -1180,7 +1180,7 @@ async fn remove_role_recursive_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -1215,7 +1215,7 @@ async fn remove_role_recursive_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -1244,7 +1244,7 @@ async fn remove_role_recursive_command() {
         .success();
 
     // Load the updated repo
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
     let repo = RepositoryLoader::new(
         &tokio::fs::read(&root_json).await.unwrap(),
         updated_metadata_base_url.clone(),
@@ -1289,7 +1289,7 @@ async fn remove_role_recursive_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1346,14 +1346,14 @@ async fn remove_role_recursive_command() {
             "--role",
             "A",
             "-i",
-            dir_url(add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path()).as_str(),
         ])
         .assert()
         .success();
 
     // Remove B from the repo
     let remove_b_out = TempDir::new().unwrap();
-    let updated_metadata_base_url = &dir_url(update_out.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(update_out.path());
 
     // remove role B from A metadata and sign A meta
     Command::cargo_bin("tuftool")
@@ -1420,7 +1420,7 @@ async fn remove_role_recursive_command() {
             "--role",
             "targets",
             "-i",
-            dir_url(remove_b_out.path().join("metadata")).as_str(),
+            dir_url(remove_b_out.path()).as_str(),
         ])
         .assert()
         .success();
@@ -1428,7 +1428,7 @@ async fn remove_role_recursive_command() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -1468,7 +1468,7 @@ async fn dubious_role_name() {
 
     // Set new expiration date for the new role
     let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path());
     let meta_out = TempDir::new().unwrap();
 
     // create role A
@@ -1503,7 +1503,7 @@ async fn dubious_role_name() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path()).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -1532,7 +1532,7 @@ async fn dubious_role_name() {
         .success();
 
     // Load the updated repo
-    let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
+    let updated_metadata_base_url = &dir_url(new_repo_dir.path());
     let updated_targets_base_url = &dir_url(new_repo_dir.path().join("targets"));
     let repo = RepositoryLoader::new(
         &tokio::fs::read(&root_json).await.unwrap(),
@@ -1578,7 +1578,7 @@ async fn dubious_role_name() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path()).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1600,12 +1600,10 @@ async fn dubious_role_name() {
     // Make sure the metadata files are in the right directory
     assert!(add_b_out
         .path()
-        .join("metadata")
         .join(format!("{}.json", dubious_name_encoded))
         .is_file());
     assert!(add_b_out
         .path()
-        .join("metadata")
         .join(format!("{}.json", funny_name_encoded))
         .is_file());
 
@@ -1641,7 +1639,7 @@ async fn dubious_role_name() {
             "--role",
             dubious_role_name,
             "-i",
-            dir_url(add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path()).as_str(),
         ])
         .assert()
         .success();
@@ -1649,7 +1647,7 @@ async fn dubious_role_name() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(update_out.path()),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -1662,12 +1660,10 @@ async fn dubious_role_name() {
     // Make sure the metadata files are in the right directory
     assert!(update_out
         .path()
-        .join("metadata")
         .join(format!("{}.{}.json", 2, dubious_name_encoded))
         .is_file());
     assert!(update_out
         .path()
-        .join("metadata")
         .join(format!("{}.{}.json", 1, funny_name_encoded))
         .is_file());
 }

--- a/tuftool/tests/download_command.rs
+++ b/tuftool/tests/download_command.rs
@@ -120,7 +120,7 @@ fn download_file_transport() {
 
 fn download_expired_repo(outdir: &Path, repo_dir: &TempDir, allow_expired_repo: bool) -> Assert {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &test_utils::dir_url(&repo_dir);
     let targets_base_url = &test_utils::dir_url(repo_dir.path().join("targets"));
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     cmd.args([

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -72,7 +72,7 @@ async fn update_command_without_new_targets() {
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
     let new_targets_version: u64 = 170;
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -107,7 +107,7 @@ async fn update_command_without_new_targets() {
     // Load the updated repo
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(&update_out),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -145,7 +145,7 @@ async fn update_command_with_new_targets() {
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
     let new_targets_version: u64 = 170;
     let new_targets_input_dir = test_utils::test_data().join("targets");
-    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -182,7 +182,7 @@ async fn update_command_with_new_targets() {
     // Load the updated repo.
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(update_out.path().join("metadata")),
+        dir_url(&update_out),
         dir_url(update_out.path().join("targets")),
     )
     .load()
@@ -306,7 +306,7 @@ fn updates_expired_repo(
     let snapshot_version: u64 = 250;
     let targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
     let targets_version: u64 = 170;
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &test_utils::dir_url(&repo_dir);
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     cmd.args([
         "update",
@@ -373,7 +373,7 @@ async fn update_command_expired_repo_allow() {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let repo = RepositoryLoader::new(
         &tokio::fs::read(root_json).await.unwrap(),
-        dir_url(outdir.path().join("metadata")),
+        dir_url(&outdir),
         dir_url(outdir.path().join("targets")),
     )
     .load()


### PR DESCRIPTION
* Implementing TUF compliant file structure to replicate below

```
└── repository
    ├── 1.root.json
    ├── root.json
    ├── snapshot.json
    ├── targets
    │   ├── ctfe-pubkey
    │   ├── fulcio-cert
    │   ├── rekor-pubkey
    │   ├── trusted_root.json
    │   ├── tsa_intermediate_0.crt.pem
    │   ├── tsa_leaf.crt.pem
    │   └── tsa_root.crt.pem
    ├── targets.json
    └── timestamp.json 
```

* Adds unversioned root.json on `tuftool update` to metadata
