### PR TITLE
optional expire flags + automated versioning

### DIFF
--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -155,6 +155,7 @@ tuftool create \
   --snapshot-version 1 \
   --timestamp-expires "${METADATA_EXPIRATION}" \
   --timestamp-version 1 \
+  --force-version \
   --outdir "${OUTDIR}"
 
 echo "Adding trust root targets ..."
@@ -171,8 +172,12 @@ if [ -n "${FULCIO_CERT}" ]; then
     --set-fulcio-target "${FULCIO_CERT}" \
     --fulcio-uri "https://fulcio.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
+    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
+    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
+    --timestamp-version 1 \
+    --force-version \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -188,8 +193,12 @@ if [ -n "${TSA_CERT}" ]; then
     --set-tsa-target "${TSA_CERT}" \
     --tsa-uri "https://tsa.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
+    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
+    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
+    --timestamp-version \
+    --force-version \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -205,8 +214,12 @@ if [ -n "${CTLOG_KEY}" ]; then
     --set-ctlog-target "${CTLOG_KEY}" \
     --ctlog-uri "https://ctlog.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
+    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
+    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
+    --timestamp-version 1 \
+    --force-version \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -222,8 +235,12 @@ if [ -n "${REKOR_KEY}" ]; then
     --set-rekor-target "${REKOR_KEY}" \
     --fulcio-uri "https://rekor.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
+    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
+    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
+    --timestamp-version 1 \
+    --force-version \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi

--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -196,7 +196,7 @@ if [ -n "${TSA_CERT}" ]; then
     --snapshot-expires "${METADATA_EXPIRATION}" \
     --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
-    --timestamp-version \
+    --timestamp-version 1 \
     --force-version \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"

--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -171,11 +171,8 @@ if [ -n "${FULCIO_CERT}" ]; then
     --set-fulcio-target "${FULCIO_CERT}" \
     --fulcio-uri "https://fulcio.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
-    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
-    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
-    --timestamp-version 1 \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -191,11 +188,8 @@ if [ -n "${TSA_CERT}" ]; then
     --set-tsa-target "${TSA_CERT}" \
     --tsa-uri "https://tsa.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
-    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
-    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
-    --timestamp-version 1 \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -211,11 +205,8 @@ if [ -n "${CTLOG_KEY}" ]; then
     --set-ctlog-target "${CTLOG_KEY}" \
     --ctlog-uri "https://ctlog.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
-    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
-    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
-    --timestamp-version 1 \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi
@@ -231,11 +222,8 @@ if [ -n "${REKOR_KEY}" ]; then
     --set-rekor-target "${REKOR_KEY}" \
     --fulcio-uri "https://rekor.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
-    --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
-    --snapshot-version 1 \
     --timestamp-expires "${METADATA_EXPIRATION}" \
-    --timestamp-version 1 \
     --outdir "${OUTDIR}" \
     --metadata-url "file://${OUTDIR}"
 fi

--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -155,7 +155,6 @@ tuftool create \
   --snapshot-version 1 \
   --timestamp-expires "${METADATA_EXPIRATION}" \
   --timestamp-version 1 \
-  --force-version \
   --outdir "${OUTDIR}"
 
 echo "Adding trust root targets ..."

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -44,9 +44,7 @@ const SPEC_VERSION: &str = "1.0.0";
 /// A new repository may be started using the `new()` method.
 ///
 /// An existing `tough::Repository` may be loaded and edited using the
-/// `from_repo()` method. When a repo is loaded in this way, versions and
-/// expirations are discarded. It is good practice to update these whenever
-/// a repo is changed.
+/// `from_repo()` method.
 ///
 /// Targets, versions, and expirations may be added to their respective roles
 /// via the provided "setter" methods. The final step in the process is the
@@ -142,8 +140,7 @@ impl RepositoryEditor {
 
     /// Given a `tough::Repository` and the path to a valid root.json, create a
     /// `RepositoryEditor`. This `RepositoryEditor` will include all of the targets
-    /// and bits of _extra metadata from the roles included. It will not, however,
-    /// include the versions or expirations and the user is expected to set them.
+    /// versions, expiration and _extra bits of data from the roles included.
     pub async fn from_repo<P>(root_path: P, repo: Repository) -> Result<RepositoryEditor>
     where
         P: AsRef<Path>,
@@ -232,7 +229,7 @@ impl RepositoryEditor {
         Ok(self)
     }
 
-    /// Add an existing `Snapshot` to the repository. Only the `_extra` data
+    /// Add an existing `Snapshot` to the repository. Only the `_extra` and `expires` data
     /// is preserved
     pub fn snapshot(&mut self, snapshot: Snapshot) -> Result<&mut Self> {
         ensure!(
@@ -243,11 +240,13 @@ impl RepositoryEditor {
             }
         );
         self.snapshot_extra = Some(snapshot._extra);
+        self.snapshot_expires = Some(snapshot.expires);
+        self.snapshot_version = snapshot.version.checked_add(1);
         Ok(self)
     }
 
-    /// Add an existing `Timestamp` to the repository. Only the `_extra` data
-    /// is preserved
+    /// Add an existing `Timestamp` to the repository. Only the `_extra`, `version`, and `expires`
+    /// data is preserved
     pub fn timestamp(&mut self, timestamp: Timestamp) -> Result<&mut Self> {
         ensure!(
             timestamp.spec_version == SPEC_VERSION,
@@ -257,6 +256,8 @@ impl RepositoryEditor {
             }
         );
         self.timestamp_extra = Some(timestamp._extra);
+        self.timestamp_expires = Some(timestamp.expires);
+        self.timestamp_version = timestamp.version.checked_add(1);
         Ok(self)
     }
 

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -47,8 +47,7 @@ const SPEC_VERSION: &str = "1.0.0";
 /// expirations are discarded. It is good practice to update these whenever
 /// a repo is changed.
 ///
-/// A  `Targets` from an existing repository can be loaded using the `from_repo()` method.
-/// `Targets` loaded this way will have the versions and expirations removed, but the
+/// A  `Targets` from an existing repository can be loaded using the `from_repo()` method.The
 /// proper keyholder to sign the targets and the `Transport` used to load the repo will be saved.
 ///
 /// Targets, versions, and expirations may be added to their respective roles
@@ -103,15 +102,14 @@ impl TargetsEditor {
     }
 
     /// Creates a `TargetsEditor` with the provided targets and keyholder
-    /// `version` and `expires` are thrown out to encourage updating the version and expiration
     pub fn from_targets(name: &str, targets: Targets, key_holder: KeyHolder) -> Self {
         TargetsEditor {
             key_holder: Some(key_holder),
             delegations: targets.delegations,
             new_targets: None,
             existing_targets: Some(targets.targets),
-            version: None,
-            expires: None,
+            version: targets.version.checked_add(1),
+            expires: Some(targets.expires),
             name: name.to_string(),
             new_roles: None,
             _extra: Some(targets._extra),
@@ -120,8 +118,7 @@ impl TargetsEditor {
         }
     }
 
-    /// Creates a `TargetsEditor` with the provided targets from an already loaded repo
-    /// `version` and `expires` are thrown out to encourage updating the version and expiration
+    /// Creates a `TargetsEditor` with the provided targets from an already loaded repo.
     /// If a `Repository` has been loaded, use `from_repo()` to preserve the `Transport` and `Limits`.
     pub fn from_repo(repo: Repository, name: &str) -> Result<Self> {
         let (targets, key_holder) = if name == "targets" {

--- a/tough/src/editor/test.rs
+++ b/tough/src/editor/test.rs
@@ -165,11 +165,5 @@ mod tests {
             .unwrap()
             .timestamp(timestamp.signed)
             .unwrap();
-
-        assert!(editor.snapshot_version.is_none());
-        assert!(editor.timestamp_version.is_none());
-
-        assert!(editor.snapshot_expires.is_none());
-        assert!(editor.timestamp_expires.is_none());
     }
 }

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -102,17 +102,16 @@ ls "${WRK}/tuf-repo/targets"
 # Change one of the target files
 echo "1.1" > "${WRK}/input/1.txt"
 
-# update tuf repo!
+# update tuf repo! Version will be automatically calculated, and expiry flags are optional. 
+# If no expires flag is passed, existing values will be passed on to the new updated version.
+# A user may forcefully change the versions by supplying the --force-version flag alongside the <metadata>-version flag.
 tuftool update \
    --root "${ROOT}" \
    --key "${WRK}/keys/root.pem" \
    --add-targets  "${WRK}/input" \
    --targets-expires 'in 3 weeks' \
-   --targets-version 2 \
    --snapshot-expires 'in 3 weeks' \
-   --snapshot-version 2 \
    --timestamp-expires 'in 1 week' \
-   --timestamp-version 2 \
    --outdir "${WRK}/tuf-repo" \
    --metadata-url file:///$WRK/tuf-repo
 
@@ -124,12 +123,6 @@ tuftool rhtas \
    --key "${WRK}/keys/root.pem" \
    --set-ctlog-target "${WRK}/input/ctfe.pub" \
    --ctlog-uri "https://ctfe.sigstore.dev" \
-   --targets-expires 'in 3 weeks' \
-   --targets-version 3 \
-   --snapshot-expires 'in 3 weeks' \
-   --snapshot-version 3 \
-   --timestamp-expires 'in 1 week' \
-   --timestamp-version 3 \
    --outdir "${WRK}/tuf-repo" \
    --metadata-url file:///$WRK/tuf-repo/
 
@@ -138,12 +131,6 @@ tuftool rhtas \
    --root "${ROOT}" \
    --key "${WRK}/keys/root.pem" \
    --delete-target "ctfe.pub" \
-   --targets-expires 'in 3 weeks' \
-   --targets-version 4 \
-   --snapshot-expires 'in 3 weeks' \
-   --snapshot-version 4 \
-   --timestamp-expires 'in 1 week' \
-   --timestamp-version 4 \
    --outdir "${WRK}/tuf-repo" \
    --metadata-url file:///$WRK/tuf-repo/
 ```

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -118,6 +118,11 @@ pub(crate) enum Error {
     #[snafu(display("Failed to remove target: Target file does not exist"))]
     TargetFileDoesNotExist { backtrace: Backtrace },
 
+    #[snafu(display(
+        "Failed to forcefully update metadata version, please supply the --force-version flag."
+    ))]
+    ForceVersionMissing { backtrace: Backtrace },
+
     #[snafu(display("Failed to read directory '{}': {}", path.display(), source))]
     ReadDir {
         path: PathBuf,

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -452,7 +452,7 @@ impl RhtasArgs {
         Ok(())
     }
 
-    fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+    fn update_metadata_version(&self, editor: &mut RepositoryEditor) {
         if self.snapshot_version.is_some() {
             let _ = editor.snapshot_version(self.snapshot_version.unwrap());
         }
@@ -462,6 +462,5 @@ impl RhtasArgs {
         if self.timestamp_version.is_some() {
             let _ = editor.timestamp_version(self.timestamp_version.unwrap());
         }
-        Ok(())
     }
 }

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -186,7 +186,7 @@ impl RhtasArgs {
         }
 
         if self.force_version {
-            let _ = self.update_metadata_version(&mut editor).await;
+            let _ = self.update_metadata_version(&mut editor);
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()
@@ -452,7 +452,7 @@ impl RhtasArgs {
         Ok(())
     }
 
-    async fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+    fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
         if self.snapshot_version.is_some() {
             let _ = editor.snapshot_version(self.snapshot_version.unwrap());
         }

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -177,6 +177,7 @@ impl RhtasArgs {
         .await
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn update_metadata(&self, mut editor: RepositoryEditor) -> Result<()> {
         let mut keys = Vec::new();
         for source in &self.keys {
@@ -185,21 +186,13 @@ impl RhtasArgs {
         }
 
         if self.force_version {
-            if self.snapshot_version.is_some() {
-                let _ = editor.snapshot_version(self.snapshot_version.unwrap());
-            }
-            if self.targets_version.is_some() {
-                let _ = editor.targets_version(self.targets_version.unwrap());
-            }
-            if self.timestamp_version.is_some() {
-                let _ = editor.timestamp_version(self.timestamp_version.unwrap());
-            }
+            let _ = self.update_metadata_version(&mut editor).await;
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()
         {
-            println!("Missing force-version flag to change metadata version forcefully.");
-        };
+            return error::ForceVersionMissingSnafu {}.fail();
+        }
 
         if let Some(_expires) = self.targets_expires {
             let _ = editor.targets_expires(self.targets_expires.unwrap());
@@ -455,6 +448,19 @@ impl RhtasArgs {
 
         if !target_found {
             return error::TargetFileDoesNotExistSnafu {}.fail();
+        }
+        Ok(())
+    }
+
+    async fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+        if self.snapshot_version.is_some() {
+            let _ = editor.snapshot_version(self.snapshot_version.unwrap());
+        }
+        if self.targets_version.is_some() {
+            let _ = editor.targets_version(self.targets_version.unwrap());
+        }
+        if self.timestamp_version.is_some() {
+            let _ = editor.timestamp_version(self.timestamp_version.unwrap());
         }
         Ok(())
     }

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -123,7 +123,7 @@ pub(crate) struct RhtasArgs {
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
     timestamp_expires: Option<DateTime<Utc>>,
-    
+
     /// Forcibly update metadata version, usage not recommended
     #[arg(long)]
     force_version: bool,

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -55,11 +55,7 @@ pub(crate) struct RhtasArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    snapshot_expires: DateTime<Utc>,
-
-    /// Version of snapshot.json file
-    #[arg(long)]
-    snapshot_version: NonZeroU64,
+    snapshot_expires: Option<DateTime<Utc>>,
 
     /// Behavior when a target exists with the same name and hash in the targets directory,
     /// for example from another repository when they share a targets directory.
@@ -121,20 +117,27 @@ pub(crate) struct RhtasArgs {
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    targets_expires: DateTime<Utc>,
-
-    /// Version of targets.json file
-    #[arg(long)]
-    targets_version: NonZeroU64,
+    targets_expires: Option<DateTime<Utc>>,
 
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    timestamp_expires: DateTime<Utc>,
+    timestamp_expires: Option<DateTime<Utc>>,
 
-    /// Version of timestamp.json file
     #[arg(long)]
-    timestamp_version: NonZeroU64,
+    force_version: bool,
+
+    /// Version of snapshot.json
+    #[arg(long)]
+    snapshot_version: Option<NonZeroU64>,
+
+    /// Version of targets.json
+    #[arg(long)]
+    targets_version: Option<NonZeroU64>,
+
+    /// Version of timestamp.json
+    #[arg(long)]
+    timestamp_version: Option<NonZeroU64>,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(path: P) {
@@ -181,16 +184,34 @@ impl RhtasArgs {
             keys.push(key_source);
         }
 
-        editor
-            .targets_version(self.targets_version)
-            .context(error::DelegationStructureSnafu)?
-            .targets_expires(self.targets_expires)
-            .context(error::DelegationStructureSnafu)?
-            .snapshot_version(self.snapshot_version)
-            .snapshot_expires(self.snapshot_expires)
-            .timestamp_version(self.timestamp_version)
-            .timestamp_expires(self.timestamp_expires);
+        if self.force_version {
+            if self.snapshot_version.is_some() {
+                let _ = editor.snapshot_version(self.snapshot_version.unwrap());
+            }
+            if self.targets_version.is_some() {
+                let _ = editor.targets_version(self.targets_version.unwrap());
+            }
+            if self.timestamp_version.is_some() {
+                let _ = editor.timestamp_version(self.timestamp_version.unwrap());
+            }
+        } else if self.snapshot_version.is_some()
+            || self.targets_version.is_some()
+            || self.timestamp_version.is_some()
+        {
+            println!("Missing force-version flag to change metadata version forcefully.");
+        };
 
+        if let Some(_expires) = self.targets_expires {
+            let _ = editor.targets_expires(self.targets_expires.unwrap());
+        }
+
+        if let Some(_expires) = self.snapshot_expires {
+            let _ = editor.snapshot_expires(self.snapshot_expires.unwrap());
+        }
+
+        if let Some(_expires) = self.timestamp_expires {
+            let _ = editor.timestamp_expires(self.timestamp_expires.unwrap());
+        };
         // If the "remove-target" argument was passed, remove the target
         // from the repository.
         for target_name in &self.delete_targets {

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -186,7 +186,7 @@ impl RhtasArgs {
         }
 
         if self.force_version {
-            let _ = self.update_metadata_version(&mut editor);
+            self.update_metadata_version(&mut editor);
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -123,7 +123,8 @@ pub(crate) struct RhtasArgs {
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
     timestamp_expires: Option<DateTime<Utc>>,
-
+    
+    /// Forcibly update metadata version, usage not recommended
     #[arg(long)]
     force_version: bool,
 

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -62,11 +62,7 @@ pub(crate) struct UpdateArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    snapshot_expires: DateTime<Utc>,
-
-    /// Version of snapshot.json file
-    #[arg(long)]
-    snapshot_version: NonZeroU64,
+    snapshot_expires: Option<DateTime<Utc>>,
 
     /// Directory of targets
     #[arg(short, long = "add-targets")]
@@ -81,20 +77,27 @@ pub(crate) struct UpdateArgs {
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    targets_expires: DateTime<Utc>,
-
-    /// Version of targets.json file
-    #[arg(long)]
-    targets_version: NonZeroU64,
+    targets_expires: Option<DateTime<Utc>>,
 
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    timestamp_expires: DateTime<Utc>,
+    timestamp_expires: Option<DateTime<Utc>>,
 
-    /// Version of timestamp.json file
     #[arg(long)]
-    timestamp_version: NonZeroU64,
+    force_version: bool,
+
+    /// Version of snapshot.json
+    #[arg(long)]
+    snapshot_version: Option<NonZeroU64>,
+
+    /// Version of targets.json
+    #[arg(long)]
+    targets_version: Option<NonZeroU64>,
+
+    /// Version of timestamp.json
+    #[arg(long)]
+    timestamp_version: Option<NonZeroU64>,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(path: P) {
@@ -141,15 +144,34 @@ impl UpdateArgs {
             keys.push(key_source);
         }
 
-        editor
-            .targets_version(self.targets_version)
-            .context(error::DelegationStructureSnafu)?
-            .targets_expires(self.targets_expires)
-            .context(error::DelegationStructureSnafu)?
-            .snapshot_version(self.snapshot_version)
-            .snapshot_expires(self.snapshot_expires)
-            .timestamp_version(self.timestamp_version)
-            .timestamp_expires(self.timestamp_expires);
+        if self.force_version {
+            if self.snapshot_version.is_some() {
+                let _ = editor.snapshot_version(self.snapshot_version.unwrap());
+            }
+            if self.targets_version.is_some() {
+                let _ = editor.targets_version(self.targets_version.unwrap());
+            }
+            if self.timestamp_version.is_some() {
+                let _ = editor.timestamp_version(self.timestamp_version.unwrap());
+            }
+        } else if self.snapshot_version.is_some()
+            || self.targets_version.is_some()
+            || self.timestamp_version.is_some()
+        {
+            println!("Missing force-version flag to change metadata version forcefully.");
+        };
+
+        if let Some(_expires) = self.targets_expires {
+            let _ = editor.targets_expires(self.targets_expires.unwrap());
+        }
+
+        if let Some(_expires) = self.snapshot_expires {
+            let _ = editor.snapshot_expires(self.snapshot_expires.unwrap());
+        }
+
+        if let Some(_expires) = self.timestamp_expires {
+            let _ = editor.timestamp_expires(self.timestamp_expires.unwrap());
+        };
 
         // If the "add-targets" argument was passed, build a list of targets
         // and add them to the repository. If a user specifies job count we

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -237,7 +237,7 @@ impl UpdateArgs {
         Ok(())
     }
 
-    fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+    fn update_metadata_version(&self, editor: &mut RepositoryEditor) {
         if self.snapshot_version.is_some() {
             let _ = editor.snapshot_version(self.snapshot_version.unwrap());
         }
@@ -247,6 +247,5 @@ impl UpdateArgs {
         if self.timestamp_version.is_some() {
             let _ = editor.timestamp_version(self.timestamp_version.unwrap());
         }
-        Ok(())
     }
 }

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -145,7 +145,7 @@ impl UpdateArgs {
         }
 
         if self.force_version {
-            let _ = self.update_metadata_version(&mut editor).await;
+            let _ = self.update_metadata_version(&mut editor);
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()
@@ -237,7 +237,7 @@ impl UpdateArgs {
         Ok(())
     }
 
-    async fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+    fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
         if self.snapshot_version.is_some() {
             let _ = editor.snapshot_version(self.snapshot_version.unwrap());
         }

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -83,7 +83,7 @@ pub(crate) struct UpdateArgs {
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
     timestamp_expires: Option<DateTime<Utc>>,
-    
+
     /// Forcibly update metadata version, usage not recommended
     #[arg(long)]
     force_version: bool,

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -145,21 +145,13 @@ impl UpdateArgs {
         }
 
         if self.force_version {
-            if self.snapshot_version.is_some() {
-                let _ = editor.snapshot_version(self.snapshot_version.unwrap());
-            }
-            if self.targets_version.is_some() {
-                let _ = editor.targets_version(self.targets_version.unwrap());
-            }
-            if self.timestamp_version.is_some() {
-                let _ = editor.timestamp_version(self.timestamp_version.unwrap());
-            }
+            let _ = self.update_metadata_version(&mut editor).await;
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()
         {
-            println!("Missing force-version flag to change metadata version forcefully.");
-        };
+            return error::ForceVersionMissingSnafu {}.fail();
+        }
 
         if let Some(_expires) = self.targets_expires {
             let _ = editor.targets_expires(self.targets_expires.unwrap());
@@ -171,7 +163,7 @@ impl UpdateArgs {
 
         if let Some(_expires) = self.timestamp_expires {
             let _ = editor.timestamp_expires(self.timestamp_expires.unwrap());
-        };
+        }
 
         // If the "add-targets" argument was passed, build a list of targets
         // and add them to the repository. If a user specifies job count we
@@ -242,6 +234,19 @@ impl UpdateArgs {
         let root_path = &self.outdir.join("root.json");
         let _ = fs::copy(&self.root, root_path);
 
+        Ok(())
+    }
+
+    async fn update_metadata_version(&self, editor: &mut RepositoryEditor) -> Result<()> {
+        if self.snapshot_version.is_some() {
+            let _ = editor.snapshot_version(self.snapshot_version.unwrap());
+        }
+        if self.targets_version.is_some() {
+            let _ = editor.targets_version(self.targets_version.unwrap());
+        }
+        if self.timestamp_version.is_some() {
+            let _ = editor.timestamp_version(self.timestamp_version.unwrap());
+        }
         Ok(())
     }
 }

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -145,7 +145,7 @@ impl UpdateArgs {
         }
 
         if self.force_version {
-            let _ = self.update_metadata_version(&mut editor);
+            self.update_metadata_version(&mut editor);
         } else if self.snapshot_version.is_some()
             || self.targets_version.is_some()
             || self.timestamp_version.is_some()

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -83,7 +83,8 @@ pub(crate) struct UpdateArgs {
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
     timestamp_expires: Option<DateTime<Utc>>,
-
+    
+    /// Forcibly update metadata version, usage not recommended
     #[arg(long)]
     force_version: bool,
 

--- a/tuftool/tests/delegation_commands.rs
+++ b/tuftool/tests/delegation_commands.rs
@@ -70,6 +70,7 @@ async fn create_add_role_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
@@ -224,10 +225,17 @@ async fn create_add_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -365,8 +373,11 @@ async fn update_target_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -384,10 +395,17 @@ async fn update_target_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -549,10 +567,17 @@ async fn add_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            "1",
             "--snapshot-expires",
             expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            "1",
             "--timestamp-expires",
             expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            "1",
+            "--force-version",
         ])
         .assert()
         .success();
@@ -630,10 +655,17 @@ async fn add_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -788,10 +820,17 @@ fn remove_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            "1",
             "--snapshot-expires",
             expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            "1",
             "--timestamp-expires",
             expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            "1",
+            "--force-version",
         ])
         .assert()
         .success();
@@ -1001,8 +1040,11 @@ async fn remove_role_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1020,10 +1062,17 @@ async fn remove_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -1065,8 +1114,11 @@ async fn remove_role_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1084,10 +1136,17 @@ async fn remove_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -1259,8 +1318,11 @@ async fn remove_role_recursive_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1278,10 +1340,17 @@ async fn remove_role_recursive_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "A",
             "-i",
@@ -1324,8 +1393,11 @@ async fn remove_role_recursive_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1343,10 +1415,17 @@ async fn remove_role_recursive_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             "targets",
             "-i",
@@ -1391,6 +1470,7 @@ async fn dubious_role_name() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
@@ -1555,10 +1635,17 @@ async fn dubious_role_name() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
             "--role",
             dubious_role_name,
             "-i",

--- a/tuftool/tests/delegation_commands.rs
+++ b/tuftool/tests/delegation_commands.rs
@@ -70,7 +70,6 @@ async fn create_add_role_command() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
@@ -225,16 +224,10 @@ async fn create_add_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -372,11 +365,8 @@ async fn update_target_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -394,16 +384,10 @@ async fn update_target_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -538,7 +522,7 @@ async fn add_key_command() {
             "-e",
             expiration.to_rfc3339().as_str(),
             "-v",
-            "1",
+            "3",
             "--delegated-role",
             "A",
         ])
@@ -565,16 +549,10 @@ async fn add_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            "1",
             "--snapshot-expires",
             expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            "1",
             "--timestamp-expires",
             expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            "1",
         ])
         .assert()
         .success();
@@ -652,16 +630,10 @@ async fn add_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -781,7 +753,7 @@ fn remove_key_command() {
             "-e",
             expiration.to_rfc3339().as_str(),
             "-v",
-            "1",
+            "3",
             "--keyid",
             "9d25bd7d096386713d823447e9920ea4b807bd95d1bf7a0d05a00979ab5eec00",
             "-k",
@@ -816,16 +788,10 @@ fn remove_key_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            "1",
             "--snapshot-expires",
             expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            "1",
             "--timestamp-expires",
             expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            "1",
         ])
         .assert()
         .success();
@@ -1035,11 +1001,8 @@ async fn remove_role_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1057,16 +1020,10 @@ async fn remove_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -1108,11 +1065,8 @@ async fn remove_role_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1130,16 +1084,10 @@ async fn remove_role_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -1311,11 +1259,8 @@ async fn remove_role_recursive_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1333,16 +1278,10 @@ async fn remove_role_recursive_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "A",
             "-i",
@@ -1385,11 +1324,8 @@ async fn remove_role_recursive_command() {
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -1407,16 +1343,10 @@ async fn remove_role_recursive_command() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             "targets",
             "-i",
@@ -1461,7 +1391,6 @@ async fn dubious_role_name() {
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
@@ -1626,16 +1555,10 @@ async fn dubious_role_name() {
             updated_metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
             "--role",
             dubious_role_name,
             "-i",

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -67,11 +67,8 @@ async fn update_command_without_new_targets() {
 
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
 
@@ -90,16 +87,10 @@ async fn update_command_without_new_targets() {
             metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
         ])
         .assert()
         .success();
@@ -118,11 +109,8 @@ async fn update_command_without_new_targets() {
     assert_eq!(repo.targets().signed.targets.len(), 3);
 
     // Ensure all the metadata has been updated
-    assert_eq!(repo.targets().signed.version.get(), new_targets_version);
     assert_eq!(repo.targets().signed.expires, new_targets_expiration);
-    assert_eq!(repo.snapshot().signed.version.get(), new_snapshot_version);
     assert_eq!(repo.snapshot().signed.expires, new_snapshot_expiration);
-    assert_eq!(repo.timestamp().signed.version.get(), new_timestamp_version);
     assert_eq!(repo.timestamp().signed.expires, new_timestamp_expiration);
 }
 
@@ -139,11 +127,8 @@ async fn update_command_with_new_targets() {
 
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let new_targets_version: u64 = 170;
     let new_targets_input_dir = test_utils::test_data().join("targets");
     let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
@@ -165,16 +150,10 @@ async fn update_command_with_new_targets() {
             metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
-            "--targets-version",
-            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
-            "--snapshot-version",
-            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
-            "--timestamp-version",
-            format!("{}", new_timestamp_version).as_str(),
         ])
         .assert()
         .success();
@@ -210,11 +189,8 @@ async fn update_command_with_new_targets() {
     );
 
     // Ensure all the metadata has been updated
-    assert_eq!(repo.targets().signed.version.get(), new_targets_version);
     assert_eq!(repo.targets().signed.expires, new_targets_expiration);
-    assert_eq!(repo.snapshot().signed.version.get(), new_snapshot_version);
     assert_eq!(repo.snapshot().signed.expires, new_snapshot_expiration);
-    assert_eq!(repo.timestamp().signed.version.get(), new_timestamp_version);
     assert_eq!(repo.timestamp().signed.expires, new_timestamp_expiration);
 }
 
@@ -288,24 +264,13 @@ fn updates_expired_repo(
     outdir: &TempDir,
     repo_dir: &TempDir,
     allow_expired_repo: bool,
-) -> (
-    Assert,
-    DateTime<Utc>,
-    u64,
-    DateTime<Utc>,
-    u64,
-    DateTime<Utc>,
-    u64,
-) {
+) -> (Assert, DateTime<Utc>, DateTime<Utc>, DateTime<Utc>) {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let root_key = test_utils::test_data().join("snakeoil.pem");
     // Set expiration dates and version numbers for the update command
     let timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
-    let timestamp_version: u64 = 310;
     let snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
-    let snapshot_version: u64 = 250;
     let targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
-    let targets_version: u64 = 170;
     let metadata_base_url = &test_utils::dir_url(&repo_dir);
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     cmd.args([
@@ -320,16 +285,10 @@ fn updates_expired_repo(
         metadata_base_url.as_str(),
         "--targets-expires",
         targets_expiration.to_rfc3339().as_str(),
-        "--targets-version",
-        format!("{}", targets_version).as_str(),
         "--snapshot-expires",
         snapshot_expiration.to_rfc3339().as_str(),
-        "--snapshot-version",
-        format!("{}", snapshot_version).as_str(),
         "--timestamp-expires",
         timestamp_expiration.to_rfc3339().as_str(),
-        "--timestamp-version",
-        format!("{}", timestamp_version).as_str(),
     ]);
     let assert = if allow_expired_repo {
         cmd.arg("--allow-expired-repo").assert()
@@ -339,11 +298,8 @@ fn updates_expired_repo(
     (
         assert,
         timestamp_expiration,
-        timestamp_version,
         snapshot_expiration,
-        snapshot_version,
         targets_expiration,
-        targets_version,
     )
 }
 
@@ -383,9 +339,6 @@ async fn update_command_expired_repo_allow() {
     assert_eq!(repo.targets().signed.targets.len(), 3);
     // Ensure all the metadata has been updated
     assert_eq!(repo.timestamp().signed.expires, update_expected.1);
-    assert_eq!(repo.timestamp().signed.version.get(), update_expected.2);
-    assert_eq!(repo.snapshot().signed.expires, update_expected.3);
-    assert_eq!(repo.snapshot().signed.version.get(), update_expected.4);
-    assert_eq!(repo.targets().signed.expires, update_expected.5);
-    assert_eq!(repo.targets().signed.version.get(), update_expected.6);
+    assert_eq!(repo.snapshot().signed.expires, update_expected.2);
+    assert_eq!(repo.targets().signed.expires, update_expected.3);
 }

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -67,8 +67,11 @@ async fn update_command_without_new_targets() {
 
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
 
@@ -87,10 +90,17 @@ async fn update_command_without_new_targets() {
             metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
         ])
         .assert()
         .success();
@@ -110,8 +120,11 @@ async fn update_command_without_new_targets() {
 
     // Ensure all the metadata has been updated
     assert_eq!(repo.targets().signed.expires, new_targets_expiration);
+    assert_eq!(repo.targets().signed.version.get(), new_targets_version);
     assert_eq!(repo.snapshot().signed.expires, new_snapshot_expiration);
+    assert_eq!(repo.snapshot().signed.version.get(), new_snapshot_version);
     assert_eq!(repo.timestamp().signed.expires, new_timestamp_expiration);
+    assert_eq!(repo.timestamp().signed.version.get(), new_timestamp_version);
 }
 
 #[tokio::test]
@@ -127,8 +140,11 @@ async fn update_command_with_new_targets() {
 
     // Set new expiration dates and version numbers for the update command
     let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_version: u64 = 310;
     let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_version: u64 = 170;
     let new_targets_input_dir = test_utils::test_data().join("targets");
     let metadata_base_url = &dir_url(&repo_dir);
     let update_out = TempDir::new().unwrap();
@@ -150,10 +166,17 @@ async fn update_command_with_new_targets() {
             metadata_base_url.as_str(),
             "--targets-expires",
             new_targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
             new_snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
             new_timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", new_timestamp_version).as_str(),
+            "--force-version",
         ])
         .assert()
         .success();
@@ -190,8 +213,11 @@ async fn update_command_with_new_targets() {
 
     // Ensure all the metadata has been updated
     assert_eq!(repo.targets().signed.expires, new_targets_expiration);
+    assert_eq!(repo.targets().signed.version.get(), new_targets_version);
     assert_eq!(repo.snapshot().signed.expires, new_snapshot_expiration);
+    assert_eq!(repo.snapshot().signed.version.get(), new_snapshot_version);
     assert_eq!(repo.timestamp().signed.expires, new_timestamp_expiration);
+    assert_eq!(repo.timestamp().signed.version.get(), new_timestamp_version);
 }
 
 #[test]
@@ -264,13 +290,24 @@ fn updates_expired_repo(
     outdir: &TempDir,
     repo_dir: &TempDir,
     allow_expired_repo: bool,
-) -> (Assert, DateTime<Utc>, DateTime<Utc>, DateTime<Utc>) {
+) -> (
+    Assert,
+    DateTime<Utc>,
+    u64,
+    DateTime<Utc>,
+    u64,
+    DateTime<Utc>,
+    u64,
+) {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let root_key = test_utils::test_data().join("snakeoil.pem");
     // Set expiration dates and version numbers for the update command
     let timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let timestamp_version: u64 = 310;
     let snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let snapshot_version: u64 = 250;
     let targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let targets_version: u64 = 170;
     let metadata_base_url = &test_utils::dir_url(&repo_dir);
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     cmd.args([
@@ -285,10 +322,17 @@ fn updates_expired_repo(
         metadata_base_url.as_str(),
         "--targets-expires",
         targets_expiration.to_rfc3339().as_str(),
+        "--targets-version",
+        format!("{}", targets_version).as_str(),
         "--snapshot-expires",
         snapshot_expiration.to_rfc3339().as_str(),
+        "--snapshot-version",
+        format!("{}", snapshot_version).as_str(),
         "--timestamp-expires",
         timestamp_expiration.to_rfc3339().as_str(),
+        "--timestamp-version",
+        format!("{}", timestamp_version).as_str(),
+        "--force-version",
     ]);
     let assert = if allow_expired_repo {
         cmd.arg("--allow-expired-repo").assert()
@@ -298,8 +342,11 @@ fn updates_expired_repo(
     (
         assert,
         timestamp_expiration,
+        timestamp_version,
         snapshot_expiration,
+        snapshot_version,
         targets_expiration,
+        targets_version,
     )
 }
 
@@ -339,6 +386,9 @@ async fn update_command_expired_repo_allow() {
     assert_eq!(repo.targets().signed.targets.len(), 3);
     // Ensure all the metadata has been updated
     assert_eq!(repo.timestamp().signed.expires, update_expected.1);
-    assert_eq!(repo.snapshot().signed.expires, update_expected.2);
-    assert_eq!(repo.targets().signed.expires, update_expected.3);
+    assert_eq!(repo.timestamp().signed.version.get(), update_expected.2);
+    assert_eq!(repo.snapshot().signed.expires, update_expected.3);
+    assert_eq!(repo.snapshot().signed.version.get(), update_expected.4);
+    assert_eq!(repo.targets().signed.expires, update_expected.5);
+    assert_eq!(repo.targets().signed.version.get(), update_expected.6);
 }


### PR DESCRIPTION
* Adding expiry values to all metadata files when using tuftool update is now optional, a user can just supply a variation of any he wants and the pre-existing expiry values that were not specified with a flag will be passed on to the new version.

* Versioning has been removed from the users hands, now it will automatically calculate a new version removing the issue of overwriting pre existing metadata files and adding general QoL. A --force-version flag exists to forcefully change the version of a specific metadata file.
