### PR TITLE
Copy targets instead of symlinking them

### DIFF
--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -120,7 +120,7 @@ impl CreateArgs {
 
         let targets_outdir = &self.outdir.join("targets");
         signed_repo
-            .link_targets(&self.targets_indir, targets_outdir, self.target_path_exists)
+            .copy_targets(&self.targets_indir, targets_outdir, self.target_path_exists)
             .await
             .context(error::LinkTargetsSnafu {
                 indir: &self.targets_indir,

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -264,7 +264,7 @@ impl RhtasArgs {
         if let Some(path) = target_path {
             let targets_outdir = &self.outdir.join("targets");
             signed_repo
-                .link_targets(path, targets_outdir, self.target_path_exists)
+                .copy_targets(path, targets_outdir, self.target_path_exists)
                 .await
                 .context(error::LinkTargetsSnafu {
                     indir: path,

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -201,7 +201,7 @@ impl UpdateArgs {
         if let Some(ref targets_indir) = self.targets_indir {
             let targets_outdir = &self.outdir.join("targets");
             signed_repo
-                .link_targets(targets_indir, targets_outdir, self.target_path_exists)
+                .copy_targets(targets_indir, targets_outdir, self.target_path_exists)
                 .await
                 .context(error::LinkTargetsSnafu {
                     indir: &targets_indir,


### PR DESCRIPTION
Changes `link_targets` to `copy_targets` so we have actual files instead of symbolic links to them within `targets`