### PR TITLE
Make tuf-repo-init overwrite secret if repo is being regenerated

### DIFF
--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -250,7 +250,7 @@ elif [ -n "${EXPORT_KEYS}" ]; then
 
   export AUTHDIR="/var/run/secrets/kubernetes.io/serviceaccount"
   export K8SCACERT="${AUTHDIR}/ca.crt"
-  export K8SSECRETS="https://kubernetes.default/api/v1/namespaces/${NAMESPACE}/secrets"
+  export K8SSECRETS="https://kubernetes.default.svc/api/v1/namespaces/${NAMESPACE}/secrets"
   export K8SAUTH=""
   export SECRET_CONTENT=""
 


### PR DESCRIPTION
Of the repo is being regenerated, we want to overwrite the secret with keys instead of failing on it. This is in line with what the Sigstore upstream TUF server does as well.