### PR TITLE
[SECURESIGN-1742] fix: rawBytes base64-encoded DER bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,8 +3833,8 @@ dependencies = [
 
 [[package]]
 name = "sigstore"
-version = "0.10.0"
-source = "git+https://github.com/securesign/sigstore-rs.git?branch=main#68aa20594d29f02ec08eb596c9d7014a0f0170fc"
+version = "0.9.0"
+source = "git+https://github.com/fghanmi/sigstore-rs.git?branch=target_v1#9d23080a5431c8c93126212906df2e14009444de"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3865,7 +3865,6 @@ dependencies = [
  "prost-types",
  "rand",
  "regex",
- "reqwest 0.11.27",
  "reqwest 0.12.7",
  "ring",
  "rsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4578,6 +4578,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "aws-sdk-ssm",
+ "base64 0.21.7",
  "chrono",
  "clap",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,8 +3833,8 @@ dependencies = [
 
 [[package]]
 name = "sigstore"
-version = "0.9.0"
-source = "git+https://github.com/fghanmi/sigstore-rs.git?branch=target_v1#9d23080a5431c8c93126212906df2e14009444de"
+version = "0.10.0"
+source = "git+https://github.com/securesign/sigstore-rs.git?branch=main#f6471008f44c57011cff9c0d921e158b48cc01b0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3865,6 +3865,7 @@ dependencies = [
  "prost-types",
  "rand",
  "regex",
+ "reqwest 0.11.27",
  "reqwest 0.12.7",
  "ring",
  "rsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -800,9 +800,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytes-utils"
@@ -841,7 +841,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1185,7 +1185,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1483,7 +1483,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2670,7 +2670,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2848,7 +2848,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2977,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -3049,7 +3049,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.98",
  "tempfile",
 ]
 
@@ -3063,7 +3063,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3099,7 +3099,7 @@ checksum = "172da1212c02be2c94901440cb27183cd92bff00ebacca5c323bf7520b8f9c04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3649,7 +3649,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3692,7 +3692,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3734,7 +3734,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3759,7 +3759,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3897,7 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3976,7 +3976,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4036,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4111,22 +4111,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4205,7 +4205,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4234,7 +4234,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4509,7 +4509,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4590,6 +4590,7 @@ dependencies = [
  "maplit",
  "olpc-cjson 0.1.3",
  "openssl",
+ "pem",
  "prost-types",
  "rayon",
  "reqwest 0.11.27",
@@ -4785,7 +4786,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -4819,7 +4820,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5243,7 +5244,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5263,5 +5264,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -35,7 +35,7 @@ serde = "1"
 serde_json = "1"
 serial_test = "3.1.1"
 simplelog = "0.12"
-sigstore = { git = "https://github.com/securesign/sigstore-rs.git", branch = "main" }
+sigstore = { git = "https://github.com/fghanmi/sigstore-rs.git", branch = "target_v1" }
 sigstore_protobuf_specs = { version = "0.3.2", optional = true }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 sha2 = "0.9"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -19,6 +19,7 @@ sigstore = ["sigstore_protobuf_specs"]
 aws-config = "1"
 aws-sdk-kms = "1"
 aws-sdk-ssm = "1"
+base64 = "0.21"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -35,7 +35,7 @@ serde = "1"
 serde_json = "1"
 serial_test = "3.1.1"
 simplelog = "0.12"
-sigstore = { git = "https://github.com/fghanmi/sigstore-rs.git", branch = "target_v1" }
+sigstore = { git = "https://github.com/securesign/sigstore-rs.git", branch = "main" }
 sigstore_protobuf_specs = { version = "0.3.2", optional = true }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 sha2 = "0.9"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -39,6 +39,7 @@ sigstore = { git = "https://github.com/securesign/sigstore-rs.git", branch = "ma
 sigstore_protobuf_specs = { version = "0.3.2", optional = true }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 sha2 = "0.9"
+pem = "3.0.4"
 prost-types = "0.12.6"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -7,6 +7,7 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use crate::TargetName;
+use base64::prelude::*;
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use openssl::ec::EcKey;
@@ -34,7 +35,6 @@ use tough::editor::signed::{PathExists, SignedRepository};
 use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
-use base64::prelude::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct RhtasArgs {
@@ -537,8 +537,8 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let certificate_raw_bytes =
-                RhtasArgs::load_target_der_bytes(fulcio_target_path).context(error::FileReadSnafu {
+            let certificate_raw_bytes = RhtasArgs::load_target_der_bytes(fulcio_target_path)
+                .context(error::FileReadSnafu {
                     path: fulcio_target_path.clone(),
                 })?;
 
@@ -613,10 +613,11 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let ctlog_raw_bytes =
-                RhtasArgs::load_target_der_bytes(ctlog_target_path).context(error::FileReadSnafu {
+            let ctlog_raw_bytes = RhtasArgs::load_target_der_bytes(ctlog_target_path).context(
+                error::FileReadSnafu {
                     path: ctlog_target_path.clone(),
-                })?;
+                },
+            )?;
 
             let key_details = RhtasArgs::detect_public_key_details(ctlog_target_path);
             if key_details.is_err() {
@@ -695,10 +696,11 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let rekor_raw_bytes =
-                RhtasArgs::load_target_der_bytes(rekor_target_path).context(error::FileReadSnafu {
+            let rekor_raw_bytes = RhtasArgs::load_target_der_bytes(rekor_target_path).context(
+                error::FileReadSnafu {
                     path: rekor_target_path.clone(),
-                })?;
+                },
+            )?;
 
             let key_details = RhtasArgs::detect_public_key_details(rekor_target_path);
             if key_details.is_err() {
@@ -777,10 +779,11 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let certificate_raw_bytes =
-                RhtasArgs::load_target_der_bytes(tsa_target_path).context(error::FileReadSnafu {
+            let certificate_raw_bytes = RhtasArgs::load_target_der_bytes(tsa_target_path).context(
+                error::FileReadSnafu {
                     path: tsa_target_path.clone(),
-                })?;
+                },
+            )?;
 
             #[allow(clippy::cast_possible_wrap)]
             let current_timestamp = SystemTime::now()
@@ -1076,14 +1079,17 @@ impl RhtasArgs {
         let mut file = File::open(target_path)?;
         let mut buffer = String::new();
         file.read_to_string(&mut buffer)?;
-    
+
         let content = buffer
             .lines()
             .filter(|line| !line.starts_with("-----"))
             .collect::<String>();
-    
+
         let decoded = BASE64_STANDARD.decode(&content).map_err(|err| {
-            io::Error::new(io::ErrorKind::InvalidData, format!("Base64 decode error: {}", err))
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Base64 decode error: {}", err),
+            )
         })?;
         Ok(decoded)
     }

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -1085,10 +1085,10 @@ impl RhtasArgs {
             .filter(|line| !line.starts_with("-----"))
             .collect::<String>();
 
-        let decoded = BASE64_STANDARD.decode(&content).map_err(|err| {
+        let decoded = BASE64_STANDARD.decode(content).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Base64 decode error: {}", err),
+                format!("Base64 decode error: {err}"),
             )
         })?;
         Ok(decoded)

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -34,6 +34,7 @@ use tough::editor::signed::{PathExists, SignedRepository};
 use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
+use base64::prelude::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct RhtasArgs {
@@ -537,7 +538,7 @@ impl RhtasArgs {
 
             // TrustedRoot
             let certificate_raw_bytes =
-                RhtasArgs::load_target_bytes(fulcio_target_path).context(error::FileReadSnafu {
+                RhtasArgs::load_target_der_bytes(fulcio_target_path).context(error::FileReadSnafu {
                     path: fulcio_target_path.clone(),
                 })?;
 
@@ -613,7 +614,7 @@ impl RhtasArgs {
 
             // TrustedRoot
             let ctlog_raw_bytes =
-                RhtasArgs::load_target_bytes(ctlog_target_path).context(error::FileReadSnafu {
+                RhtasArgs::load_target_der_bytes(ctlog_target_path).context(error::FileReadSnafu {
                     path: ctlog_target_path.clone(),
                 })?;
 
@@ -695,7 +696,7 @@ impl RhtasArgs {
 
             // TrustedRoot
             let rekor_raw_bytes =
-                RhtasArgs::load_target_bytes(rekor_target_path).context(error::FileReadSnafu {
+                RhtasArgs::load_target_der_bytes(rekor_target_path).context(error::FileReadSnafu {
                     path: rekor_target_path.clone(),
                 })?;
 
@@ -777,7 +778,7 @@ impl RhtasArgs {
 
             // TrustedRoot
             let certificate_raw_bytes =
-                RhtasArgs::load_target_bytes(tsa_target_path).context(error::FileReadSnafu {
+                RhtasArgs::load_target_der_bytes(tsa_target_path).context(error::FileReadSnafu {
                     path: tsa_target_path.clone(),
                 })?;
 
@@ -859,7 +860,7 @@ impl RhtasArgs {
                 let file_path = entry.path();
 
                 let identifier =
-                    RhtasArgs::load_target_bytes(&file_path).context(error::FileReadSnafu {
+                    RhtasArgs::load_target_der_bytes(&file_path).context(error::FileReadSnafu {
                         path: file_path.clone(),
                     })?;
 
@@ -1071,11 +1072,20 @@ impl RhtasArgs {
         ))
     }
 
-    fn load_target_bytes(target_path: &std::path::Path) -> io::Result<Vec<u8>> {
+    fn load_target_der_bytes(target_path: &Path) -> io::Result<Vec<u8>> {
         let mut file = File::open(target_path)?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)?;
-        Ok(buffer)
+        let mut buffer = String::new();
+        file.read_to_string(&mut buffer)?;
+    
+        let content = buffer
+            .lines()
+            .filter(|line| !line.starts_with("-----"))
+            .collect::<String>();
+    
+        let decoded = BASE64_STANDARD.decode(&content).map_err(|err| {
+            io::Error::new(io::ErrorKind::InvalidData, format!("Base64 decode error: {}", err))
+        })?;
+        Ok(decoded)
     }
 
     fn get_latest_trusted_root(&self) -> PathBuf {

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -7,7 +7,6 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use crate::TargetName;
-use base64::prelude::*;
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use openssl::ec::EcKey;
@@ -35,7 +34,6 @@ use tough::editor::signed::{PathExists, SignedRepository};
 use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
-
 #[derive(Debug, Parser)]
 pub(crate) struct RhtasArgs {
     /// Allow repo download for expired metadata
@@ -1087,28 +1085,14 @@ impl RhtasArgs {
         let mut buffer = String::new();
         file.read_to_string(&mut buffer)?;
 
-        let mut result = Vec::new();
-        let mut content = String::new();
-        let mut inside_block = false;
+        let pems = pem::parse_many(buffer).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("PEM parse error: {err}"),
+            )
+        })?;
 
-        for line in buffer.lines() {
-            if line.starts_with("-----BEGIN") {
-                content.clear();
-                inside_block = true;
-            } else if line.starts_with("-----END") {
-                let decoded = BASE64_STANDARD.decode(&content).map_err(|err| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Base64 decode error: {err}"),
-                    )
-                })?;
-                result.push(decoded);
-                inside_block = false;
-            } else if inside_block {
-                content.push_str(line);
-            }
-        }
-        Ok(result)
+        Ok(pems.into_iter().map(pem::Pem::into_contents).collect())
     }
 
     fn get_latest_trusted_root(&self) -> PathBuf {

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -537,7 +537,7 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let certificate_raw_bytes = RhtasArgs::load_target_der_bytes(fulcio_target_path)
+            let certificate_raw_bytes_vec = RhtasArgs::load_target_der_bytes(fulcio_target_path)
                 .context(error::FileReadSnafu {
                     path: fulcio_target_path.clone(),
                 })?;
@@ -560,17 +560,19 @@ impl RhtasArgs {
                 end = timestamp;
                 start = None;
             }
+
+            let mut certificates: Vec<X509Certificate> = Vec::new();
+            for item in certificate_raw_bytes_vec {
+                certificates.push(X509Certificate { raw_bytes: item });
+            }
+
             let new_ca = CertificateAuthority {
                 subject: Some(DistinguishedName {
                     organization: "sigstore.dev".to_string(),
                     common_name: "sigstore".to_string(),
                 }),
                 uri: self.fulcio_uri.clone().unwrap(),
-                cert_chain: Some(X509CertificateChain {
-                    certificates: vec![X509Certificate {
-                        raw_bytes: certificate_raw_bytes,
-                    }],
-                }),
+                cert_chain: Some(X509CertificateChain { certificates }),
                 valid_for: Some(TimeRange { start, end }),
             };
 
@@ -613,7 +615,7 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let ctlog_raw_bytes = RhtasArgs::load_target_der_bytes(ctlog_target_path).context(
+            let ctlog_raw_bytes_vec = RhtasArgs::load_target_der_bytes(ctlog_target_path).context(
                 error::FileReadSnafu {
                     path: ctlog_target_path.clone(),
                 },
@@ -624,8 +626,10 @@ impl RhtasArgs {
                 return error::InvalidPublicKeySnafu {}.fail();
             }
 
+            let ctlog_raw_bytes = ctlog_raw_bytes_vec[0].clone();
+
             let mut hasher = Sha256::new();
-            hasher.update(&ctlog_raw_bytes);
+            hasher.update(ctlog_raw_bytes.clone());
             let hash_result = hasher.finalize();
             let key_id = hash_result.to_vec();
 
@@ -696,7 +700,7 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let rekor_raw_bytes = RhtasArgs::load_target_der_bytes(rekor_target_path).context(
+            let rekor_raw_bytes_vec = RhtasArgs::load_target_der_bytes(rekor_target_path).context(
                 error::FileReadSnafu {
                     path: rekor_target_path.clone(),
                 },
@@ -707,8 +711,10 @@ impl RhtasArgs {
                 return error::InvalidPublicKeySnafu {}.fail();
             }
 
+            let rekor_raw_bytes = rekor_raw_bytes_vec[0].clone();
+
             let mut hasher = Sha256::new();
-            hasher.update(&rekor_raw_bytes);
+            hasher.update(rekor_raw_bytes.clone());
             let hash_result = hasher.finalize();
             let key_id = hash_result.to_vec();
 
@@ -779,11 +785,10 @@ impl RhtasArgs {
             }
 
             // TrustedRoot
-            let certificate_raw_bytes = RhtasArgs::load_target_der_bytes(tsa_target_path).context(
-                error::FileReadSnafu {
+            let certificate_raw_bytes_vec = RhtasArgs::load_target_der_bytes(tsa_target_path)
+                .context(error::FileReadSnafu {
                     path: tsa_target_path.clone(),
-                },
-            )?;
+                })?;
 
             #[allow(clippy::cast_possible_wrap)]
             let current_timestamp = SystemTime::now()
@@ -803,17 +808,19 @@ impl RhtasArgs {
                 end = timestamp;
                 start = None;
             }
+
+            let mut certificates: Vec<X509Certificate> = Vec::new();
+            for item in certificate_raw_bytes_vec {
+                certificates.push(X509Certificate { raw_bytes: item });
+            }
+
             let new_tsa = CertificateAuthority {
                 subject: Some(DistinguishedName {
                     organization: "sigstore.dev".to_string(),
                     common_name: "sigstore".to_string(),
                 }),
                 uri: self.tsa_uri.clone().unwrap(),
-                cert_chain: Some(X509CertificateChain {
-                    certificates: vec![X509Certificate {
-                        raw_bytes: certificate_raw_bytes,
-                    }],
-                }),
+                cert_chain: Some(X509CertificateChain { certificates }),
                 valid_for: Some(TimeRange { start, end }),
             };
 
@@ -874,7 +881,7 @@ impl RhtasArgs {
                         path: file_path.clone(),
                     })?;
                 // Remove target from TrustedRoot
-                match sigstore_trust_root.delete_target(&target_type, &identifier) {
+                match sigstore_trust_root.delete_target(&target_type, &identifier[0]) {
                     Ok(()) => {}
                     Err(e) => {
                         eprintln!("Failed to delete target: {e:?} from trusted_root");
@@ -1075,23 +1082,33 @@ impl RhtasArgs {
         ))
     }
 
-    fn load_target_der_bytes(target_path: &Path) -> io::Result<Vec<u8>> {
+    fn load_target_der_bytes(target_path: &Path) -> io::Result<Vec<Vec<u8>>> {
         let mut file = File::open(target_path)?;
         let mut buffer = String::new();
         file.read_to_string(&mut buffer)?;
 
-        let content = buffer
-            .lines()
-            .filter(|line| !line.starts_with("-----"))
-            .collect::<String>();
+        let mut result = Vec::new();
+        let mut content = String::new();
+        let mut inside_block = false;
 
-        let decoded = BASE64_STANDARD.decode(content).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Base64 decode error: {err}"),
-            )
-        })?;
-        Ok(decoded)
+        for line in buffer.lines() {
+            if line.starts_with("-----BEGIN") {
+                content.clear();
+                inside_block = true;
+            } else if line.starts_with("-----END") {
+                let decoded = BASE64_STANDARD.decode(&content).map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Base64 decode error: {err}"),
+                    )
+                })?;
+                result.push(decoded);
+                inside_block = false;
+            } else if inside_block {
+                content.push_str(line);
+            }
+        }
+        Ok(result)
     }
 
     fn get_latest_trusted_root(&self) -> PathBuf {


### PR DESCRIPTION
**Changes in this PR:**
- **Fix rawBytes** to be based on base64-encoded DER bytes
- **Support for Certificate Chain Targets:** handle certificate chains with multiple certificates
- **Integration Tests Updates:** update integrations tests according to the above