### PR TITLE
fix cargo clippy failures

### DIFF
--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -833,7 +833,6 @@ impl RepositoryEditor {
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
     /// Build the `Snapshot` struct
-    #[allow(clippy::ref_option)]
     fn build_snapshot(
         &self,
         signed_targets: &SignedRole<Targets>,

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -292,7 +292,8 @@ impl RepositoryEditor {
             })
         };
 
-        let signed_snapshot = self.build_snapshot(&signed_targets, &signed_delegated_targets)?;
+        let signed_snapshot =
+            self.build_snapshot(&signed_targets, signed_delegated_targets.as_ref())?;
         let signed_snapshot = SignedRole::new(signed_snapshot, &root, keys, &rng).await?;
         let signed_timestamp = self.build_timestamp(&signed_snapshot)?;
         let signed_timestamp = SignedRole::new(signed_timestamp, &root, keys, &rng).await?;

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -188,7 +188,8 @@ impl RepositoryEditor {
             })
         };
 
-        let signed_snapshot = self.build_snapshot(&signed_targets, &signed_delegated_targets)?;
+        let signed_snapshot =
+            self.build_snapshot(&signed_targets, signed_delegated_targets.as_ref())?;
         let signed_snapshot = SignedRole::new(signed_snapshot, &root, keys, &rng).await?;
         let signed_timestamp = self.build_timestamp(&signed_snapshot)?;
         let signed_timestamp = SignedRole::new(signed_timestamp, &root, keys, &rng).await?;
@@ -836,7 +837,7 @@ impl RepositoryEditor {
     fn build_snapshot(
         &self,
         signed_targets: &SignedRole<Targets>,
-        signed_delegated_targets: &Option<SignedDelegatedTargets>,
+        signed_delegated_targets: Option<&SignedDelegatedTargets>,
     ) -> Result<Snapshot> {
         let version = self.snapshot_version.context(error::MissingSnafu {
             field: "snapshot version",
@@ -854,7 +855,7 @@ impl RepositoryEditor {
             .meta
             .insert("targets.json".to_owned(), targets_meta);
 
-        if let Some(signed_delegated_targets) = signed_delegated_targets.as_ref() {
+        if let Some(signed_delegated_targets) = signed_delegated_targets {
             for delegated_targets in &signed_delegated_targets.roles {
                 let meta = Self::snapshot_meta(delegated_targets);
                 snapshot.meta.insert(

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -833,6 +833,7 @@ impl RepositoryEditor {
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
     /// Build the `Snapshot` struct
+    #[allow(clippy::ref_option)]
     fn build_snapshot(
         &self,
         signed_targets: &SignedRole<Targets>,

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -32,6 +32,7 @@ pub trait Sign: Sync + Send {
 
 /// Implements `Sign` for a reference to any type that implements `Sign`.
 #[async_trait]
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: Sign> Sign for &'a T {
     fn tuf_key(&self) -> Key {
         (*self).tuf_key()

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -32,7 +32,7 @@ pub trait Sign: Sync + Send {
 
 /// Implements `Sign` for a reference to any type that implements `Sign`.
 #[async_trait]
-impl<'a, T: Sign> Sign for &'a T {
+impl<T: Sign> Sign for &T {
     fn tuf_key(&self) -> Key {
         (*self).tuf_key()
     }

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -32,7 +32,6 @@ pub trait Sign: Sync + Send {
 
 /// Implements `Sign` for a reference to any type that implements `Sign`.
 #[async_trait]
-#[allow(clippy::needless_lifetimes)]
 impl<'a, T: Sign> Sign for &'a T {
     fn tuf_key(&self) -> Key {
         (*self).tuf_key()

--- a/tough/tests/test_utils.rs
+++ b/tough/tests/test_utils.rs
@@ -14,7 +14,6 @@ use tough::IntoVec;
 use url::Url;
 
 /// Utilities for tests. Not every test module uses every function, so we suppress unused warnings.
-
 pub const DATA_1: &str = "123\n456\n789\n0\n";
 pub const DATA_2: &str = "abc\ndef\nhij\nk\n";
 pub const DATA_3: &str = "!@#\n$%^\n&*(\n)\n";

--- a/tuftool/tests/test_utils.rs
+++ b/tuftool/tests/test_utils.rs
@@ -8,7 +8,6 @@ use tough::IntoVec;
 use url::Url;
 
 /// Utilities for tests. Not every test module uses every function, so we suppress unused warnings.
-
 /// Returns the path to our test data directory
 #[allow(unused)]
 pub fn test_data() -> PathBuf {


### PR DESCRIPTION
Since `cargo 1.84.0`, `cargo clippy --locked -- -D warnings` throws 2 failures.