### PR TITLE
Exit with different status code in case of existing repository

### DIFF
--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -101,7 +101,7 @@ fi
 
 if [ -e "${TUF_REPO_PATH}/root.json" ]; then
   echo "Repo seems to already be initialized (${TUF_REPO_PATH}/root.json exists)"
-  exit 1
+  exit 2
 fi
 
 export WORKDIR=""


### PR DESCRIPTION
A 'repository already exists' state doesn't necessarily mean an error. Using a distinct exit code for this scenario allows the tuf-job init to correctly signal success when no update is needed for an existing repository, while still ensuring it fails appropriately for misconfigurations.

## Summary by Sourcery

Enhancements:
- Return exit code 2 when the repository is already initialized to distinguish it from error conditions.