### PR TITLE
[SECURESIGN-1397] embed sigstore-rs trust functions into tough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,50 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,12 +25,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -537,7 +487,7 @@ dependencies = [
  "httparse",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -680,18 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,12 +650,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -770,24 +702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2",
 ]
 
 [[package]]
@@ -850,51 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cached"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
-dependencies = [
- "ahash 0.8.11",
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.14.5",
- "once_cell",
- "thiserror 1.0.69",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cbor-diag"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,12 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,10 +822,8 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -991,17 +852,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -1069,22 +919,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -1162,103 +996,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "crypto_secretbox"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
-dependencies = [
- "aead",
- "cipher",
- "generic-array",
- "poly1305",
- "salsa20",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.99",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.99",
 ]
 
 [[package]]
@@ -1268,43 +1012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
-name = "decoded-char"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
-
-[[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1335,7 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1370,70 +1082,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core",
- "serde",
- "sha2 0.10.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1443,6 +1095,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1496,32 +1154,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flagset"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 
 [[package]]
 name = "fnv"
@@ -1631,6 +1267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1311,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1723,17 +1364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,7 +1375,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util 0.7.13",
@@ -1764,7 +1394,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util 0.7.13",
@@ -1779,25 +1409,6 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
 ]
 
 [[package]]
@@ -1823,15 +1434,6 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
 
 [[package]]
 name = "hmac"
@@ -1871,15 +1473,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http-auth"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2051,22 +1644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,12 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,34 +1826,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
  "serde",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
 ]
 
 [[package]]
@@ -2296,15 +1846,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2331,28 +1872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,138 +1891,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-number"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66994b2bac615128d07a1e4527ad29e98b004dd1a1769e7b8fbc1173ccf43006"
-dependencies = [
- "lexical",
- "ryu-js",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "json-syntax"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9"
-dependencies = [
- "decoded-char",
- "hashbrown 0.12.3",
- "indexmap 1.9.3",
- "json-number",
- "locspan",
- "locspan-derive",
- "ryu-js",
- "serde",
- "smallstr",
- "smallvec",
- "utf8-decode",
-]
-
-[[package]]
-name = "jwt"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
-dependencies = [
- "base64 0.13.1",
- "crypto-common",
- "digest 0.10.7",
- "hmac",
- "serde",
- "serde_json",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical"
-version = "7.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ed980ff02623721dc334b9105150b66d0e1f246a92ab5a2eca0335d54c48f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -2518,20 +1915,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2547,24 +1944,6 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
-]
-
-[[package]]
-name = "locspan"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33890449fcfac88e94352092944bf321f55e5deb4e289a6f51c87c55731200a0"
-
-[[package]]
-name = "locspan-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88991223b049a3d29ca1f60c05639581336a0f3ee4bf8a659dddecc11c4961a"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2692,12 +2071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,23 +2134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,17 +2145,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -2821,7 +2166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2834,60 +2178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.15",
- "http 0.2.12",
- "rand",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.9.0",
- "block2",
- "libc",
- "objc2",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,47 +2187,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-distribution"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "http 1.2.0",
- "http-auth",
- "jwt",
- "lazy_static",
- "olpc-cjson 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex",
- "reqwest 0.12.12",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "unicase",
-]
-
-[[package]]
 name = "olpc-cjson"
 version = "0.1.4"
 dependencies = [
  "serde",
  "serde_derive",
- "serde_json",
- "unicode-normalization",
-]
-
-[[package]]
-name = "olpc-cjson"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
-dependencies = [
- "serde",
  "serde_json",
  "unicode-normalization",
 ]
@@ -2953,38 +2207,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openidconnect"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "dyn-clone",
- "ed25519-dalek",
- "hmac",
- "http 0.2.12",
- "itertools 0.10.5",
- "log",
- "oauth2",
- "p256",
- "p384",
- "rand",
- "rsa",
- "serde",
- "serde-value",
- "serde_derive",
- "serde_json",
- "serde_path_to_error",
- "serde_plain",
- "serde_with",
- "sha2 0.10.8",
- "subtle",
- "thiserror 1.0.69",
- "url",
-]
 
 [[package]]
 name = "openssl"
@@ -3062,30 +2284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,31 +2307,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "pem"
@@ -3143,15 +2320,6 @@ checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3167,7 +2335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap",
 ]
 
 [[package]]
@@ -3203,59 +2371,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2 0.10.8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "pkcs5",
- "rand_core",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "powerfmt"
@@ -3320,12 +2439,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "proc-macro-crate"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "elliptic-curve",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3363,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3373,13 +2492,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
  "heck",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3394,12 +2512,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -3407,34 +2525,56 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.12.0"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "once_cell",
  "prost",
- "prost-reflect-derive",
+ "prost-reflect-derive 0.14.0",
  "prost-types",
  "serde",
  "serde-value",
 ]
 
 [[package]]
-name = "prost-reflect-build"
-version = "0.12.0"
+name = "prost-reflect"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d0aa0c82e0fc36214c77b4dabe00750b3c41be45055baf2631cbbb7769b8ca"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+dependencies = [
+ "prost",
+ "prost-reflect-derive 0.15.1",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8db7191445b1dbee19df4f6b6294e5123aef52620b344a630bb845d302622a"
 dependencies = [
  "prost-build",
- "prost-reflect",
+ "prost-reflect 0.15.3",
 ]
 
 [[package]]
 name = "prost-reflect-derive"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172da1212c02be2c94901440cb27183cd92bff00ebacca5c323bf7520b8f9c04"
+checksum = "f4fce6b22f15cc8d8d400a2b98ad29202b33bd56c7d9ddd815bc803a807ecb65"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab076798900edeaf1499ed1c30097db86e6697c5d02660a63d72fe4ebdcfefd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3443,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -3621,6 +2761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,7 +2781,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -3652,12 +2798,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.13",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -3677,14 +2821,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3698,7 +2839,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util 0.7.13",
  "tower 0.5.2",
@@ -3709,16 +2849,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "windows-registry",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3745,23 +2875,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.7"
+name = "rstest"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
 dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "subtle",
- "zeroize",
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.99",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3800,7 +2940,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3876,11 +3029,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -3916,21 +3070,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "ryu-js"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "same-file"
@@ -3972,18 +3111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,20 +3125,6 @@ name = "sdd"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -4097,7 +3210,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -4124,17 +3237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,36 +3246,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.99",
 ]
 
 [[package]]
@@ -4199,17 +3271,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -4261,75 +3322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core",
-]
-
-[[package]]
-name = "sigstore"
-version = "0.10.0"
-source = "git+https://github.com/securesign/sigstore-rs.git?branch=main#ba603637992b9ae3b9515d5bd301e91a63207db2"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "cached",
- "cfg-if",
- "chrono",
- "const-oid",
- "crypto_secretbox",
- "digest 0.10.7",
- "ecdsa",
- "ed25519",
- "ed25519-dalek",
- "elliptic-curve",
- "futures",
- "futures-util",
- "getrandom 0.2.15",
- "hex",
- "json-syntax",
- "lazy_static",
- "oci-distribution",
- "olpc-cjson 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openidconnect",
- "p256",
- "p384",
- "pem",
- "pkcs1",
- "pkcs8",
- "prost-types",
- "rand",
- "regex",
- "reqwest 0.11.27",
- "reqwest 0.12.12",
- "ring",
- "rsa",
- "rustls-webpki 0.102.8",
- "scrypt",
- "serde",
- "serde_json",
- "serde_repr",
- "serde_with",
- "sha2 0.10.8",
- "signature",
- "sigstore_protobuf_specs",
- "thiserror 1.0.69",
- "tls_codec",
- "tokio",
- "tokio-util 0.7.13",
- "tough 0.18.0",
- "tracing",
- "url",
- "webbrowser",
- "x509-cert",
- "zeroize",
-]
-
-[[package]]
 name = "sigstore-protobuf-specs-derive"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,21 +3333,21 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d18b16bf8b6628bd34c2cd915476ff2a707b4e288995f3d675668c48c4a73d7"
+checksum = "799e5ed827a6d8d2be7fc598515d061b59d85f496d7066152822a80f3250af74"
 dependencies = [
  "anyhow",
  "glob",
  "prost",
  "prost-build",
- "prost-reflect",
+ "prost-reflect 0.14.7",
  "prost-reflect-build",
  "prost-types",
  "serde",
  "serde_json",
  "sigstore-protobuf-specs-derive",
- "which 6.0.3",
+ "which 7.0.3",
 ]
 
 [[package]]
@@ -4376,16 +3368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "smallstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
-dependencies = [
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -4429,32 +3411,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4547,7 +3507,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -4675,27 +3635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,7 +3644,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4817,37 +3755,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tough"
-version = "0.18.0"
+name = "toml_datetime"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a11e87698820a64152f36682e12017944619631d1a4881aaad532cbd843d5dc"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "async-recursion",
- "async-trait",
- "bytes",
- "chrono",
- "dyn-clone",
- "futures",
- "futures-core",
- "globset",
- "hex",
- "log",
- "olpc-cjson 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "pem",
- "percent-encoding",
- "reqwest 0.11.27",
- "ring",
- "serde",
- "serde_json",
- "serde_plain",
- "snafu",
- "tempfile",
- "tokio",
- "tokio-util 0.7.13",
- "typed-path",
- "untrusted 0.9.0",
- "url",
- "walkdir",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4867,11 +3788,11 @@ dependencies = [
  "hex",
  "hex-literal",
  "httptest",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.13.0",
  "log",
  "maplit",
- "olpc-cjson 0.1.4",
+ "olpc-cjson",
  "pem",
  "percent-encoding",
  "reqwest 0.12.12",
@@ -4909,7 +3830,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
- "tough 0.19.0",
+ "tough",
 ]
 
 [[package]]
@@ -4921,7 +3842,7 @@ dependencies = [
  "aws-smithy-experimental",
  "snafu",
  "tokio",
- "tough 0.19.0",
+ "tough",
 ]
 
 [[package]]
@@ -5094,36 +4015,43 @@ dependencies = [
  "aws-lc-rs",
  "aws-sdk-kms",
  "aws-sdk-ssm",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "futures",
  "futures-core",
+ "futures-util",
  "hex",
  "httptest",
- "indexmap 2.7.1",
+ "indexmap",
  "log",
  "maplit",
- "olpc-cjson 0.1.4",
+ "olpc-cjson",
  "openssl",
  "pem",
  "prost-types",
  "rayon",
+ "regex",
  "reqwest 0.12.12",
+ "rstest",
  "rustls 0.23.23",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
  "serial_test",
  "sha2 0.9.9",
- "sigstore",
  "sigstore_protobuf_specs",
  "simplelog",
  "snafu",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
- "tough 0.19.0",
+ "tokio-util 0.7.13",
+ "tough",
  "tough-kms",
  "tough-ssm",
+ "tracing",
  "url",
  "walkdir",
 ]
@@ -5162,16 +4090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5192,7 +4110,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -5206,12 +4123,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-decode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8_iter"
@@ -5403,24 +4314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9fe1ebb156110ff855242c1101df158b822487e4957b0556d9ffce9db0f535"
-dependencies = [
- "block2",
- "core-foundation 0.10.0",
- "home",
- "jni",
- "log",
- "ndk-context",
- "objc2",
- "objc2-foundation",
- "url",
- "web-sys",
-]
-
-[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5429,18 +4322,18 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
- "home",
- "rustix",
+ "env_home",
+ "rustix 1.0.7",
  "winsafe",
 ]
 
@@ -5466,7 +4359,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5522,15 +4415,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5554,21 +4438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5604,12 +4473,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5622,12 +4485,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5637,12 +4494,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5664,12 +4515,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5679,12 +4524,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5700,12 +4539,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5718,12 +4551,6 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -5733,6 +4560,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -5770,20 +4606,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid",
- "der",
- "sha1",
- "signature",
- "spki",
- "tls_codec",
-]
 
 [[package]]
 name = "xmlparser"
@@ -5868,20 +4690,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
 
 [[package]]
 name = "zerovec"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -10,18 +10,24 @@ edition = "2018"
 
 [features]
 integ = []
-default = ["aws-sdk-rust","sigstore_protobuf_specs"]
+default = ["aws-sdk-rust","sigstore_protobuf_specs","sigstore-trust-root"]
 aws-sdk-rust = ["aws-sdk-rust-rustls"]
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-ssm/rustls", "aws-sdk-kms/rustls", ]
 sigstore = ["sigstore_protobuf_specs"]
 fips = ["tough/fips", "rustls/fips"]
+
+sigstore-trust-root = [
+  "sigstore_protobuf_specs",
+  "futures-util",
+  "regex",
+  "tokio/sync",
+]
 
 [dependencies]
 aws-config = { version = "1", default-features = false, features = ["credentials-process"] }
 aws-lc-rs = "1"
 aws-sdk-kms = "1"
 aws-sdk-ssm = "1"
-base64 = "0.21"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
@@ -37,12 +43,13 @@ serde = "1"
 serde_json = "1"
 serial_test = "3.1.1"
 simplelog = "0.12"
-sigstore = { git = "https://github.com/securesign/sigstore-rs.git", branch = "main" }
-sigstore_protobuf_specs = { version = "0.3.2", optional = true }
+
+sigstore_protobuf_specs = { version = "0.4", default-features = false, optional = true }
+
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 sha2 = "0.9"
 pem = "3.0.4"
-prost-types = "0.12.6"
+prost-types = "0.13.5"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tough = { version = "0.19", path = "../tough", features = ["http"] }
@@ -51,6 +58,16 @@ tough-ssm = { version = "0.14", path = "../tough-ssm" }
 url = "2"
 walkdir = "2"
 indexmap = { version = "2.5.0", features = ["serde"] }
+
+rustls-webpki = { version = "0.102.1", features = ["alloc"] }
+thiserror = "1.0.30"
+base64 = { version = "0.22", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.30", optional = true }
+tokio-util = { version = "0.7.10", features = ["io-util"] }
+tracing = "0.1.31"
+rstest = "0.22.0"
+regex = { version = "1.5.5", optional = true }
+pki-types = { package = "rustls-pki-types", version = "1.12", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -26,6 +26,7 @@ mod remove_key_role;
 mod remove_role;
 mod rhtas;
 mod root;
+mod sigstore_trust;
 mod source;
 mod transfer_metadata;
 mod update;

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -5,6 +5,8 @@ use crate::build_targets;
 use crate::common::UNUSED_URL;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
+#[cfg(feature = "sigstore-trust-root")]
+use crate::sigstore_trust::trust::sigstore::{SigstoreTrustRoot, Target, TargetType};
 use crate::source::parse_key_source;
 use crate::TargetName;
 use chrono::{DateTime, Utc};
@@ -17,7 +19,6 @@ use prost_types::Timestamp;
 use serde_json::from_reader;
 use serde_json::json;
 use sha2::{Digest, Sha256};
-use sigstore::trust::sigstore::{SigstoreTrustRoot, Target, TargetType};
 use sigstore_protobuf_specs::dev::sigstore::{
     common::v1::{
         DistinguishedName, LogId, PublicKey, TimeRange, X509Certificate, X509CertificateChain,
@@ -179,6 +180,8 @@ WARNING: `--allow-expired-repo` was passed; this is unsafe and will not establis
               path.as_ref().display());
 }
 
+#[allow(deprecated)]
+#[allow(clippy::clone_on_copy)]
 impl RhtasArgs {
     pub(crate) async fn run(&mut self) -> Result<()> {
         self.validate_and_set_defaults()?;
@@ -572,6 +575,7 @@ impl RhtasArgs {
                 uri: self.fulcio_uri.clone().unwrap(),
                 cert_chain: Some(X509CertificateChain { certificates }),
                 valid_for: Some(TimeRange { start, end }),
+                operator: String::new(),
             };
 
             match trusted_root
@@ -657,8 +661,9 @@ impl RhtasArgs {
                     key_details: key_details.unwrap(),
                     valid_for: Some(TimeRange { start, end }),
                 }),
-                log_id: Some(LogId { key_id }),
-                checkpoint_key_id: None,
+                checkpoint_key_id: Some(LogId { key_id }),
+                log_id: None,
+                operator: String::new(),
             };
 
             match trusted_root.set_target(TargetType::Log(new_ctlog), Target::Ctlog) {
@@ -742,8 +747,9 @@ impl RhtasArgs {
                     key_details: key_details.unwrap(),
                     valid_for: Some(TimeRange { start, end }),
                 }),
-                log_id: Some(LogId { key_id }),
-                checkpoint_key_id: None,
+                checkpoint_key_id: Some(LogId { key_id }),
+                log_id: None,
+                operator: String::new(),
             };
 
             match trusted_root.set_target(TargetType::Log(new_tlog), Target::Tlog) {
@@ -820,6 +826,7 @@ impl RhtasArgs {
                 uri: self.tsa_uri.clone().unwrap(),
                 cert_chain: Some(X509CertificateChain { certificates }),
                 valid_for: Some(TimeRange { start, end }),
+                operator: String::new(),
             };
 
             match trusted_root

--- a/tuftool/src/sigstore_trust/errors.rs
+++ b/tuftool/src/sigstore_trust/errors.rs
@@ -1,0 +1,59 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The errors that can be raised by sigstore-rs
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, SigstoreError>;
+
+#[derive(Error, Debug)]
+#[allow(clippy::enum_variant_names)]
+#[allow(dead_code)]
+pub enum SigstoreError {
+    #[error("failed to parse URL: {0}")]
+    UrlParseError(#[from] url::ParseError),
+
+    #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
+
+    #[cfg(feature = "sigstore-trust-root")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sigstore-trust-root")))]
+    #[error(transparent)]
+    TufError(#[from] Box<tough::error::Error>),
+
+    #[error("TUF target {0} not found inside of repository")]
+    TufTargetNotFoundError(String),
+
+    #[error("{0}")]
+    TufMetadataError(String),
+
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+
+    #[error("{0}")]
+    UnexpectedError(String),
+
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::error::Error),
+
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+
+    #[error(transparent)]
+    WebPKIError(#[from] webpki::Error),
+
+    #[error("serialization error: {0}")]
+    SerializationError(String),
+}

--- a/tuftool/src/sigstore_trust/mod.rs
+++ b/tuftool/src/sigstore_trust/mod.rs
@@ -1,0 +1,2 @@
+pub mod errors;
+pub mod trust;

--- a/tuftool/src/sigstore_trust/trust/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/mod.rs
@@ -1,0 +1,52 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pki_types::CertificateDer;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "sigstore-trust-root")))]
+#[cfg(feature = "sigstore-trust-root")]
+pub mod sigstore;
+
+#[allow(dead_code)]
+/// A `TrustRoot` owns all key material necessary for establishing a root of trust.
+pub trait TrustRoot {
+    fn fulcio_certs(&self) -> crate::sigstore_trust::errors::Result<Vec<CertificateDer<'_>>>;
+    fn rekor_keys(&self) -> crate::sigstore_trust::errors::Result<Vec<&[u8]>>;
+    fn ctfe_keys(&self) -> crate::sigstore_trust::errors::Result<Vec<&[u8]>>;
+}
+
+#[allow(clippy::doc_markdown)]
+/// A `ManualTrustRoot` is a [TrustRoot] with out-of-band trust materials.
+/// As it does not establish a trust root with TUF, users must initialize its materials themselves.
+#[derive(Debug, Default)]
+pub struct ManualTrustRoot<'a> {
+    pub fulcio_certs: Vec<CertificateDer<'a>>,
+    pub rekor_keys: Vec<Vec<u8>>,
+    pub ctfe_keys: Vec<Vec<u8>>,
+}
+
+impl TrustRoot for ManualTrustRoot<'_> {
+    fn fulcio_certs(&self) -> crate::sigstore_trust::errors::Result<Vec<CertificateDer<'_>>> {
+        Ok(self.fulcio_certs.clone())
+    }
+
+    fn rekor_keys(&self) -> crate::sigstore_trust::errors::Result<Vec<&[u8]>> {
+        Ok(self.rekor_keys.iter().map(|key| &key[..]).collect())
+    }
+
+    fn ctfe_keys(&self) -> crate::sigstore_trust::errors::Result<Vec<&[u8]>> {
+        Ok(self.ctfe_keys.iter().map(|v| &v[..]).collect())
+    }
+}

--- a/tuftool/src/sigstore_trust/trust/sigstore/constants.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/constants.rs
@@ -1,0 +1,37 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(dead_code)]
+pub(crate) const SIGSTORE_METADATA_BASE: &str = "https://tuf-repo-cdn.sigstore.dev";
+pub(crate) const SIGSTORE_TARGET_BASE: &str = "https://tuf-repo-cdn.sigstore.dev/targets";
+
+macro_rules! impl_static_resource {
+    {$($name:literal,)+} => {
+        #[inline]
+        pub(crate) fn static_resource<N>(name: N) -> Option<&'static [u8]> where N: AsRef<str> {
+            match name.as_ref() {
+            $(
+                $name => Some(include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/trust_root/prod/", $name)))
+            ),+,
+                    _ => None,
+            }
+        }
+    };
+}
+
+impl_static_resource! {
+    "root.json",
+    "trusted_root.json",
+}

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -1,0 +1,1061 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helper Structs to interact with the Sigstore TUF repository.
+//!
+//! The main interaction point is [`SigstoreTrustRoot`], which fetches Rekor's
+//! public key and Fulcio's certificate.
+//!
+//! These can later be given to [`cosign::ClientBuilder`](crate::cosign::ClientBuilder)
+//! to enable Fulcio and Rekor integrations.
+use futures_util::TryStreamExt;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use tokio_util::bytes::BytesMut;
+
+use pki_types::CertificateDer;
+use sigstore_protobuf_specs::dev::sigstore::{
+    common::v1::TimeRange,
+    trustroot::v1::{CertificateAuthority, TransparencyLogInstance, TrustedRoot},
+};
+use std::str;
+use tough::TargetName;
+use tracing::debug;
+
+mod constants;
+use crate::sigstore_trust::errors::{Result, SigstoreError};
+#[allow(unused_imports)]
+pub use crate::sigstore_trust::trust::{ManualTrustRoot, TrustRoot};
+use std::convert::TryInto;
+
+/// Securely fetches Rekor public key and Fulcio certificates from Sigstore's TUF repository.
+#[derive(Debug)]
+pub struct SigstoreTrustRoot {
+    trusted_root: TrustedRoot,
+}
+
+pub enum TargetType {
+    Authority(CertificateAuthority),
+    Log(TransparencyLogInstance),
+}
+pub enum Target {
+    CertificateAuthority,
+    TimestampAuthority,
+    Ctlog,
+    Tlog,
+}
+
+#[allow(dead_code)]
+#[allow(clippy::implicit_clone)]
+#[allow(clippy::redundant_closure_for_method_calls)]
+#[allow(clippy::flat_map_option)]
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::unnecessary_map_or)]
+#[allow(clippy::unnecessary_wraps)]
+#[allow(clippy::clone_on_copy)]
+impl SigstoreTrustRoot {
+    // Needed to construct SigstoreTrustRoot from trusted_root.json
+    pub fn from_trusted_root(trusted_root: TrustedRoot) -> Self {
+        SigstoreTrustRoot { trusted_root }
+    }
+    /// Constructs a new trust root from a [`tough::Repository`].
+    async fn from_tough(
+        repository: &tough::Repository,
+        checkout_dir: Option<&Path>,
+    ) -> Result<Self> {
+        let trusted_root = {
+            let data = Self::fetch_target(repository, checkout_dir, "trusted_root.json").await?;
+            serde_json::from_slice(&data[..])?
+        };
+
+        Ok(Self { trusted_root })
+    }
+
+    /// Constructs a new trust root backed by the Sigstore Public Good Instance.
+    pub async fn new(cache_dir: Option<&Path>) -> Result<Self> {
+        // These are statically defined and should always parse correctly.
+        let metadata_base = url::Url::parse(constants::SIGSTORE_METADATA_BASE)?;
+        let target_base = url::Url::parse(constants::SIGSTORE_TARGET_BASE)?;
+
+        let repository = tough::RepositoryLoader::new(
+            &constants::static_resource("root.json").expect("Failed to fetch embedded TUF root!"),
+            metadata_base,
+            target_base,
+        )
+        .expiration_enforcement(tough::ExpirationEnforcement::Safe)
+        .load()
+        .await
+        .map_err(Box::new)?;
+
+        Self::from_tough(&repository, cache_dir).await
+    }
+
+    async fn fetch_target<N>(
+        repository: &tough::Repository,
+        checkout_dir: Option<&Path>,
+        name: N,
+    ) -> Result<Vec<u8>>
+    where
+        N: TryInto<TargetName, Error = tough::error::Error>,
+    {
+        let name: TargetName = name.try_into().map_err(Box::new)?;
+        let local_path = checkout_dir.as_ref().map(|d| d.join(name.raw()));
+
+        let read_remote_target = || async {
+            match repository.read_target(&name).await {
+                Ok(Some(s)) => Ok(s.try_collect::<BytesMut>().await.map_err(Box::new)?),
+                _ => Err(SigstoreError::TufTargetNotFoundError(name.raw().to_owned())),
+            }
+        };
+
+        // First, try reading the target from disk cache.
+        let data = if let Some(Ok(local_data)) = local_path.as_ref().map(std::fs::read) {
+            debug!("{}: reading from disk cache", name.raw());
+            local_data.to_vec()
+        // Try reading the target embedded into the binary.
+        } else if let Some(embedded_data) = constants::static_resource(name.raw()) {
+            debug!("{}: reading from embedded resources", name.raw());
+            embedded_data.to_vec()
+        // If all else fails, read the data from the TUF repo.
+        } else if let Ok(remote_data) = read_remote_target().await {
+            debug!("{}: reading from remote", name.raw());
+            remote_data.to_vec()
+        } else {
+            return Err(SigstoreError::TufTargetNotFoundError(name.raw().to_owned()));
+        };
+
+        // Get metadata (hash) of the target and update the disk copy if it doesn't match.
+        let Some(target) = repository.targets().signed.targets.get(&name) else {
+            return Err(SigstoreError::TufMetadataError(format!(
+                "couldn't get metadata for {}",
+                name.raw()
+            )));
+        };
+
+        let data = if Sha256::digest(&data)[..] == target.hashes.sha256[..] {
+            data
+        } else {
+            debug!("{}: out of date", name.raw());
+            read_remote_target().await?.to_vec()
+        };
+
+        // Write our updated data back to the disk.
+        if let Some(local_path) = local_path {
+            std::fs::write(local_path, &data)?;
+        }
+
+        Ok(data)
+    }
+
+    #[inline]
+    fn tlog_keys(tlogs: &[TransparencyLogInstance]) -> impl Iterator<Item = &[u8]> {
+        tlogs
+            .iter()
+            .filter_map(|tlog| tlog.public_key.as_ref())
+            .filter(|key| is_timerange_valid(key.valid_for.as_ref(), false))
+            .filter_map(|key| key.raw_bytes.as_ref())
+            .map(|key_bytes| key_bytes.as_slice())
+    }
+
+    #[inline]
+    fn ca_keys(
+        cas: &[CertificateAuthority],
+        allow_expired: bool,
+    ) -> impl Iterator<Item = &'_ [u8]> {
+        cas.iter()
+            .filter(move |ca| is_timerange_valid(ca.valid_for.as_ref(), allow_expired))
+            .flat_map(|ca| ca.cert_chain.as_ref())
+            .flat_map(|chain| chain.certificates.iter())
+            .map(|cert| cert.raw_bytes.as_slice())
+    }
+    /// Save the trusted root to a file
+    pub fn save_to_file(&self, file_path: &Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(&self.trusted_root)
+            .map_err(|e| SigstoreError::SerializationError(e.to_string()))?;
+
+        std::fs::write(file_path, json).map_err(SigstoreError::from)
+    }
+
+    // SECURESIGN-2010
+    pub fn is_corrupted_raw_bytes(raw_bytes: &[u8]) -> bool {
+        if let Ok(text) = str::from_utf8(raw_bytes) {
+            if text.contains("-----BEGIN") {
+                return true;
+            }
+        }
+        false
+    }
+
+    // Set a target in the TrustedRoot: Add or Update
+    pub fn set_target(&mut self, new_target: TargetType, target_name: Target) -> Result<()> {
+        // Step 1: Remove all corrupted targets of the given type
+        match target_name {
+            Target::CertificateAuthority => {
+                self.trusted_root.certificate_authorities.retain(|ca| {
+                    ca.cert_chain.as_ref().map_or(true, |chain| {
+                        let clean_certs: Vec<_> = chain
+                            .certificates
+                            .iter()
+                            .filter(|cert| {
+                                let corrupted =
+                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                !corrupted
+                            })
+                            .cloned()
+                            .collect();
+
+                        !clean_certs.is_empty()
+                    })
+                });
+            }
+            Target::TimestampAuthority => {
+                self.trusted_root.timestamp_authorities.retain(|tsa| {
+                    tsa.cert_chain.as_ref().map_or(true, |chain| {
+                        let clean_certs: Vec<_> = chain
+                            .certificates
+                            .iter()
+                            .filter(|cert| {
+                                let corrupted =
+                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                !corrupted
+                            })
+                            .cloned()
+                            .collect();
+
+                        !clean_certs.is_empty()
+                    })
+                });
+            }
+            Target::Ctlog => {
+                self.trusted_root.ctlogs.retain(|ctlog| {
+                    let corrupted = ctlog.public_key.as_ref().map_or(false, |key| {
+                        key.raw_bytes
+                            .as_ref()
+                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                    });
+                    !corrupted
+                });
+            }
+            Target::Tlog => {
+                self.trusted_root.tlogs.retain(|tlog| {
+                    let corrupted = tlog.public_key.as_ref().map_or(false, |key| {
+                        key.raw_bytes
+                            .as_ref()
+                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                    });
+                    !corrupted
+                });
+            }
+        }
+
+        // Step 2: Proceed with normal setup after cleanup
+        match target_name {
+            Target::CertificateAuthority => {
+                if let TargetType::Authority(mut ca) = new_target {
+                    // Check if the Certificate Authority already exists
+                    let exists = self
+                        .trusted_root
+                        .certificate_authorities
+                        .iter()
+                        .any(|existing_ca| existing_ca.cert_chain == ca.cert_chain);
+
+                    // If exists, update the Certificate Authority
+                    if exists {
+                        if let Some(existing_ca) = self
+                            .trusted_root
+                            .certificate_authorities
+                            .iter_mut()
+                            .find(|existing_ca| existing_ca.cert_chain == ca.cert_chain)
+                        {
+                            // If valid_for.start is not set; User wants to expire the target
+                            if let Some(valid_for) = &mut ca.valid_for {
+                                if valid_for.start.is_none() {
+                                    valid_for.start = existing_ca.valid_for.unwrap().start;
+                                }
+                            }
+                            existing_ca.clone_from(&ca);
+                        }
+                    } else {
+                        // Add the new Certificate Authority if it doesn't exist
+                        if let Some(last_ca) = self.trusted_root.certificate_authorities.last_mut()
+                        {
+                            if let Some(valid_for) = &mut last_ca.valid_for {
+                                if valid_for.end.is_none() {
+                                    valid_for.end = ca.valid_for.unwrap().start;
+                                }
+                            }
+                        }
+                        self.trusted_root.certificate_authorities.push(ca);
+                    }
+                } else {
+                    return Err(SigstoreError::UnexpectedError(
+                        "Expected a CertificateAuthority, but got a different target.".to_string(),
+                    ));
+                }
+            }
+            Target::TimestampAuthority => {
+                if let TargetType::Authority(mut tsa) = new_target {
+                    let exists = self
+                        .trusted_root
+                        .timestamp_authorities
+                        .iter()
+                        .any(|existing_tsa| existing_tsa.cert_chain == tsa.cert_chain);
+
+                    if exists {
+                        if let Some(existing_tsa) = self
+                            .trusted_root
+                            .timestamp_authorities
+                            .iter_mut()
+                            .find(|existing_tsa| existing_tsa.cert_chain == tsa.cert_chain)
+                        {
+                            // If valid_for.start is not set; User wants to expire the target
+                            if let Some(valid_for) = &mut tsa.valid_for {
+                                if valid_for.start.is_none() {
+                                    valid_for.start = existing_tsa.valid_for.clone().unwrap().start;
+                                }
+                            }
+                            existing_tsa.clone_from(&tsa);
+                        }
+                    } else {
+                        if let Some(last_tsa) = self.trusted_root.timestamp_authorities.last_mut() {
+                            if let Some(valid_for) = &mut last_tsa.valid_for {
+                                if valid_for.end.is_none() {
+                                    valid_for.end = tsa.valid_for.unwrap().start;
+                                }
+                            }
+                        }
+                        self.trusted_root.timestamp_authorities.push(tsa);
+                    }
+                } else {
+                    return Err(SigstoreError::UnexpectedError(
+                        "Expected a TimestampAuthority, but got a different target.".to_string(),
+                    ));
+                }
+            }
+            Target::Ctlog => {
+                if let TargetType::Log(mut ctlog) = new_target {
+                    let exists = self.trusted_root.ctlogs.iter().any(|existing_ctlog| {
+                        existing_ctlog.checkpoint_key_id == ctlog.checkpoint_key_id
+                            || existing_ctlog.public_key == ctlog.public_key
+                    });
+
+                    if exists {
+                        if let Some(existing_ctlog) =
+                            self.trusted_root.ctlogs.iter_mut().find(|existing_ctlog| {
+                                existing_ctlog.checkpoint_key_id == ctlog.checkpoint_key_id
+                            })
+                        {
+                            // If valid_for.start is not set; User wants to expire the target
+                            if let Some(valid_for) = &mut ctlog
+                                .public_key
+                                .as_mut()
+                                .and_then(|pk| pk.valid_for.as_mut())
+                            {
+                                if valid_for.start.is_none() {
+                                    valid_for.start = existing_ctlog
+                                        .clone()
+                                        .public_key
+                                        .unwrap()
+                                        .valid_for
+                                        .unwrap()
+                                        .start;
+                                }
+                            }
+                            existing_ctlog.clone_from(&ctlog);
+                        }
+                    } else {
+                        if let Some(last_ctlog) = self.trusted_root.ctlogs.last_mut() {
+                            if let Some(valid_for) = last_ctlog
+                                .public_key
+                                .as_mut()
+                                .and_then(|pk| pk.valid_for.as_mut())
+                            {
+                                if valid_for.end.is_none() {
+                                    valid_for.end =
+                                        ctlog.clone().public_key.unwrap().valid_for.unwrap().start;
+                                }
+                            }
+                        }
+                        self.trusted_root.ctlogs.push(ctlog);
+                    }
+                } else {
+                    return Err(SigstoreError::UnexpectedError(
+                        "Expected a Ctlog, but got a different target.".to_string(),
+                    ));
+                }
+            }
+            Target::Tlog => {
+                if let TargetType::Log(mut tlog) = new_target {
+                    let exists = self.trusted_root.tlogs.iter().any(|existing_tlog| {
+                        existing_tlog.checkpoint_key_id == tlog.checkpoint_key_id
+                            || existing_tlog.public_key == tlog.public_key
+                    });
+
+                    if exists {
+                        if let Some(existing_tlog) =
+                            self.trusted_root.tlogs.iter_mut().find(|existing_tlog| {
+                                existing_tlog.checkpoint_key_id == tlog.checkpoint_key_id
+                            })
+                        {
+                            // If valid_for.start is not set; User wants to expire the target
+                            if let Some(valid_for) = &mut tlog
+                                .public_key
+                                .as_mut()
+                                .and_then(|pk| pk.valid_for.as_mut())
+                            {
+                                if valid_for.start.is_none() {
+                                    valid_for.start = existing_tlog
+                                        .clone()
+                                        .public_key
+                                        .unwrap()
+                                        .valid_for
+                                        .unwrap()
+                                        .start;
+                                }
+                            }
+                            existing_tlog.clone_from(&tlog);
+                        }
+                    } else {
+                        if let Some(last_tlog) = self.trusted_root.tlogs.last_mut() {
+                            if let Some(valid_for) = last_tlog
+                                .public_key
+                                .as_mut()
+                                .and_then(|pk| pk.valid_for.as_mut())
+                            {
+                                if valid_for.end.is_none() {
+                                    valid_for.end =
+                                        tlog.clone().public_key.unwrap().valid_for.unwrap().start;
+                                }
+                            }
+                        }
+                        self.trusted_root.tlogs.push(tlog);
+                    }
+                } else {
+                    return Err(SigstoreError::UnexpectedError(
+                        "Expected a Tlog, but got a different target.".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // Delete a target from the TrustedRoot by its identifier raw bytes:
+    // public key for tlogs and ctlogs, cert chain for certificate and timestamp authorities)
+    pub fn delete_target(&mut self, target_type: &Target, identifier: &Vec<u8>) -> Result<()> {
+        // Step 1: Remove all corrupted targets of the given type
+        match target_type {
+            Target::CertificateAuthority => {
+                self.trusted_root.certificate_authorities.retain(|ca| {
+                    ca.cert_chain.as_ref().map_or(true, |chain| {
+                        let clean_certs: Vec<_> = chain
+                            .certificates
+                            .iter()
+                            .filter(|cert| {
+                                let corrupted =
+                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                !corrupted
+                            })
+                            .cloned()
+                            .collect();
+
+                        !clean_certs.is_empty()
+                    })
+                });
+            }
+            Target::TimestampAuthority => {
+                self.trusted_root.timestamp_authorities.retain(|tsa| {
+                    tsa.cert_chain.as_ref().map_or(true, |chain| {
+                        let clean_certs: Vec<_> = chain
+                            .certificates
+                            .iter()
+                            .filter(|cert| {
+                                let corrupted =
+                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                !corrupted
+                            })
+                            .cloned()
+                            .collect();
+
+                        !clean_certs.is_empty()
+                    })
+                });
+            }
+            Target::Ctlog => {
+                self.trusted_root.ctlogs.retain(|ctlog| {
+                    let corrupted = ctlog.public_key.as_ref().map_or(false, |key| {
+                        key.raw_bytes
+                            .as_ref()
+                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                    });
+                    !corrupted
+                });
+            }
+            Target::Tlog => {
+                self.trusted_root.tlogs.retain(|tlog| {
+                    let corrupted = tlog.public_key.as_ref().map_or(false, |key| {
+                        key.raw_bytes
+                            .as_ref()
+                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                    });
+                    !corrupted
+                });
+            }
+        }
+
+        // Step 2: Proceed with normal deletion after cleanup
+        match target_type {
+            Target::CertificateAuthority => {
+                self.trusted_root.certificate_authorities.retain(|ca| {
+                    ca.cert_chain.as_ref().map_or(true, |chain| {
+                        chain
+                            .certificates
+                            .iter()
+                            .all(|cert| cert.raw_bytes != *identifier)
+                    })
+                });
+            }
+            Target::TimestampAuthority => {
+                self.trusted_root.timestamp_authorities.retain(|tsa| {
+                    tsa.cert_chain.as_ref().map_or(true, |chain| {
+                        chain
+                            .certificates
+                            .iter()
+                            .all(|cert| cert.raw_bytes != *identifier)
+                    })
+                });
+            }
+            Target::Ctlog => {
+                self.trusted_root.ctlogs.retain(|ctlog| {
+                    ctlog
+                        .public_key
+                        .as_ref()
+                        .map_or(true, |key| key.raw_bytes != Some(identifier.clone()))
+                });
+            }
+            Target::Tlog => {
+                self.trusted_root.tlogs.retain(|tlog| {
+                    tlog.public_key
+                        .as_ref()
+                        .map_or(true, |key| key.raw_bytes != Some(identifier.clone()))
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustRoot {
+    /// Fetch Fulcio certificates from the given TUF repository or reuse
+    /// the local cache if its contents are not outdated.
+    ///
+    /// The contents of the local cache are updated when they are outdated.
+    fn fulcio_certs(&self) -> Result<Vec<CertificateDer<'_>>> {
+        // Allow expired certificates: they may have been active when the
+        // certificate was used to sign.
+        let certs = Self::ca_keys(&self.trusted_root.certificate_authorities, true);
+        let certs: Vec<_> = certs
+            .map(|c| CertificateDer::from(c).into_owned())
+            .collect();
+
+        if certs.is_empty() {
+            Err(SigstoreError::TufMetadataError(
+                "Fulcio certificates not found".into(),
+            ))
+        } else {
+            Ok(certs)
+        }
+    }
+
+    /// Fetch Rekor public keys from the given TUF repository or reuse
+    /// the local cache if it's not outdated.
+    ///
+    /// The contents of the local cache are updated when they are outdated.
+    fn rekor_keys(&self) -> Result<Vec<&[u8]>> {
+        let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.tlogs).collect();
+
+        if keys.len() == 1 {
+            Ok(keys)
+        } else {
+            Err(SigstoreError::TufMetadataError(
+                "Did not find exactly 1 active Rekor key".into(),
+            ))
+        }
+    }
+
+    /// Fetch CTFE public keys from the given TUF repository or reuse
+    /// the local cache if it's not outdated.
+    ///
+    /// The contents of the local cache are updated when they are outdated.
+    fn ctfe_keys(&self) -> Result<Vec<&[u8]>> {
+        let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.ctlogs).collect();
+
+        if keys.is_empty() {
+            Err(SigstoreError::TufMetadataError(
+                "CTFE keys not found".into(),
+            ))
+        } else {
+            Ok(keys)
+        }
+    }
+}
+
+/// Given a `range`, checks that the the current time is not before `start`. If
+/// `allow_expired` is `false`, also checks that the current time is not after
+/// `end`.
+fn is_timerange_valid(range: Option<&TimeRange>, allow_expired: bool) -> bool {
+    let now = chrono::Utc::now().timestamp();
+
+    let start = range.and_then(|r| r.start.as_ref()).map(|t| t.seconds);
+    let end = range.and_then(|r| r.end.as_ref()).map(|t| t.seconds);
+
+    match (start, end) {
+        // If there was no validity period specified, the key is always valid.
+        (None, _) => true,
+        // Active: if the current time is before the starting period, we are not yet valid.
+        (Some(start), _) if now < start => false,
+        // If we want Expired keys, then we don't need to check the end.
+        _ if allow_expired => true,
+        // If there is no expiry date, the key is valid.
+        (_, None) => true,
+        // If we have an expiry date, check it.
+        (_, Some(end)) => now <= end,
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use super::*;
+    use prost_types::Timestamp;
+    use rstest::{fixture, rstest};
+    use sigstore_protobuf_specs::dev::sigstore::{
+        common::v1::{
+            DistinguishedName, LogId, PublicKey, TimeRange, X509Certificate, X509CertificateChain,
+        },
+        trustroot::v1::{CertificateAuthority, TransparencyLogInstance},
+    };
+    use std::fs;
+    use std::path::Path;
+    use std::time::SystemTime;
+    use tempfile::TempDir;
+
+    fn verify(root: &SigstoreTrustRoot, cache_dir: Option<&Path>) {
+        if let Some(cache_dir) = cache_dir {
+            assert!(
+                cache_dir.join("trusted_root.json").exists(),
+                "the trusted root was not cached"
+            );
+        }
+
+        assert!(
+            root.fulcio_certs().is_ok_and(|v| !v.is_empty()),
+            "no Fulcio certs established"
+        );
+        assert!(
+            root.rekor_keys().is_ok_and(|v| !v.is_empty()),
+            "no Rekor keys established"
+        );
+        assert!(
+            root.ctfe_keys().is_ok_and(|v| !v.is_empty()),
+            "no CTFE keys established"
+        );
+    }
+
+    #[fixture]
+    fn cache_dir() -> TempDir {
+        TempDir::new().expect("cannot create temp cache dir")
+    }
+
+    async fn trust_root(cache: Option<&Path>) -> SigstoreTrustRoot {
+        SigstoreTrustRoot::new(cache)
+            .await
+            .expect("failed to construct SigstoreTrustRoot")
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn trust_root_fetch(#[values(None, Some(cache_dir()))] cache: Option<TempDir>) {
+        let cache = cache.as_ref().map(|t| t.path());
+        let root = trust_root(cache).await;
+
+        verify(&root, cache);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn trust_root_outdated(cache_dir: TempDir) {
+        let trusted_root_path = cache_dir.path().join("trusted_root.json");
+        let outdated_data = b"fake trusted root";
+        fs::write(&trusted_root_path, outdated_data)
+            .expect("failed to write to trusted root cache");
+
+        let cache = Some(cache_dir.path());
+        let root = trust_root(cache).await;
+        verify(&root, cache);
+
+        let data = fs::read(&trusted_root_path).expect("failed to read from trusted root cache");
+        assert_ne!(data, outdated_data, "TUF cache was not properly updated");
+    }
+
+    #[test]
+    fn test_is_timerange_valid() {
+        fn range_from(start: i64, end: i64) -> TimeRange {
+            let base = chrono::Utc::now();
+            let start: SystemTime = (base + chrono::TimeDelta::seconds(start)).into();
+            let end: SystemTime = (base + chrono::TimeDelta::seconds(end)).into();
+
+            TimeRange {
+                start: Some(start.into()),
+                end: Some(end.into()),
+            }
+        }
+
+        assert!(is_timerange_valid(None, true));
+        assert!(is_timerange_valid(None, false));
+
+        // Test lower bound conditions
+
+        // Valid: 1 ago, 1 from now
+        assert!(is_timerange_valid(Some(&range_from(-1, 1)), false));
+        // Invalid: 1 from now, 1 from now
+        assert!(!is_timerange_valid(Some(&range_from(1, 1)), false));
+
+        // Test upper bound conditions
+
+        // Invalid: 1 ago, 1 ago
+        assert!(!is_timerange_valid(Some(&range_from(-1, -1)), false));
+        // Valid: 1 ago, 1 ago
+        assert!(is_timerange_valid(Some(&range_from(-1, -1)), true))
+    }
+
+    #[tokio::test]
+    async fn test_add_new_certificate_authority() {
+        let cache_dir = None;
+        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+            .await
+            .expect("Failed to create SigstoreTrustRoot");
+        let initial_length = trust_root.trusted_root.certificate_authorities.len();
+        let new_ca = CertificateAuthority {
+            subject: Some(DistinguishedName {
+                organization: "sigstore.dev".to_string(),
+                common_name: "sigstore".to_string(),
+            }),
+            uri: "https://fulcio_test.sigstore.dev".to_string(),
+            cert_chain: Some(X509CertificateChain {
+                certificates: vec![
+                    X509Certificate {
+                        raw_bytes: String::from("MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLguhzAKBggqhkjOPQQDAzAqMRUwEwYDVQEKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==").as_bytes().to_vec(),
+                    },
+                ],
+            }),
+            valid_for: Some(TimeRange{
+                start: Some(Timestamp{
+                    seconds: 1724155691,
+                    nanos: 0,
+                }),
+                end: None,
+            }),
+            operator: "".to_string()
+        };
+        let result =
+            trust_root.set_target(TargetType::Authority(new_ca), Target::CertificateAuthority);
+        assert!(result.is_ok(), "Failed to add new certificate authority");
+        let new_length = trust_root.trusted_root.certificate_authorities.len();
+        assert_eq!(
+            trust_root.trusted_root.certificate_authorities.len(),
+            initial_length + 1
+        );
+
+        let added_ca = &trust_root.trusted_root.certificate_authorities[new_length - 1];
+        assert_eq!(added_ca.uri, "https://fulcio_test.sigstore.dev");
+        assert_eq!(
+            added_ca.valid_for.as_ref().unwrap().start,
+            Some(Timestamp {
+                seconds: 1724155691,
+                nanos: 0,
+            })
+        );
+        // Check expired certificate authority
+        if initial_length > 0 {
+            assert_eq!(
+                trust_root.trusted_root.certificate_authorities[new_length - 2]
+                    .valid_for
+                    .as_ref()
+                    .unwrap()
+                    .end,
+                Some(Timestamp {
+                    seconds: 1724155691,
+                    nanos: 0,
+                })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_certificate_authority() {
+        let cache_dir = None;
+        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+            .await
+            .expect("Failed to create SigstoreTrustRoot");
+        let initial_length = trust_root.trusted_root.certificate_authorities.len();
+
+        // Update the last certificate authority
+        let ca = &trust_root.trusted_root.certificate_authorities[initial_length - 1];
+        let mut updated_ca = ca.clone();
+        updated_ca.subject = Some(DistinguishedName {
+            organization: "sigstore.test".to_string(),
+            common_name: "sigstore".to_string(),
+        });
+        updated_ca.valid_for = Some(TimeRange {
+            start: Some(Timestamp {
+                seconds: 1724155691,
+                nanos: 0,
+            }),
+            end: None,
+        });
+        let result = trust_root.set_target(
+            TargetType::Authority(updated_ca),
+            Target::CertificateAuthority,
+        );
+        let new_length = trust_root.trusted_root.certificate_authorities.len();
+        let ca = &trust_root.trusted_root.certificate_authorities[new_length - 1];
+        assert!(result.is_ok(), "Failed to update certificate authority");
+        assert_eq!(
+            ca.subject,
+            Some(DistinguishedName {
+                organization: "sigstore.test".to_string(),
+                common_name: "sigstore".to_string(),
+            })
+        );
+        assert_eq!(
+            ca.valid_for.as_ref().unwrap().start,
+            Some(Timestamp {
+                seconds: 1724155691,
+                nanos: 0,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_new_ctlog() {
+        let cache_dir = None;
+        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+            .await
+            .expect("Failed to create SigstoreTrustRoot");
+        let initial_length = trust_root.trusted_root.ctlogs.len();
+        let new_ctlog = TransparencyLogInstance {
+            base_url: String::from("https://ctfe.sigstore.dev/test"),
+            hash_algorithm: 256,
+            public_key: Some(PublicKey{
+                raw_bytes: Some(String::from("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==").as_bytes().to_vec()),
+                key_details: 256,
+                valid_for: Some(TimeRange{
+                    start: Some(Timestamp{
+                        seconds: 1724155691,
+                        nanos: 0,
+                    }),
+                    end: None,
+                }),
+            }),
+            log_id: None,
+            checkpoint_key_id: Some(LogId {
+                key_id: String::from("CGCS8RhS/2hG0drJ4ScRWcYrBY9wzjSbea8IgY2b3I=").as_bytes().to_vec(),
+            }),
+            operator: "".to_string()
+        };
+
+        let result = trust_root.set_target(TargetType::Log(new_ctlog), Target::Ctlog);
+        assert!(result.is_ok(), "Failed to add new Ctlog entry");
+        let new_length = trust_root.trusted_root.ctlogs.len();
+        assert_eq!(trust_root.trusted_root.ctlogs.len(), initial_length + 1);
+
+        let added_ctlog: &TransparencyLogInstance = &trust_root.trusted_root.ctlogs[new_length - 1];
+        assert_eq!(added_ctlog.base_url, "https://ctfe.sigstore.dev/test");
+        assert_eq!(
+            added_ctlog
+                .clone()
+                .public_key
+                .unwrap()
+                .valid_for
+                .as_ref()
+                .unwrap()
+                .start,
+            Some(Timestamp {
+                seconds: 1724155691,
+                nanos: 0,
+            })
+        );
+        // Check expired ctlog
+        if initial_length > 0 {
+            assert_eq!(
+                trust_root.trusted_root.ctlogs[new_length - 2]
+                    .clone()
+                    .public_key
+                    .unwrap()
+                    .valid_for
+                    .as_ref()
+                    .unwrap()
+                    .end,
+                Some(Timestamp {
+                    seconds: 1724155691,
+                    nanos: 0,
+                })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_certificate_authority() {
+        let cache_dir = None;
+        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+            .await
+            .expect("Failed to create SigstoreTrustRoot");
+
+        // Add a new CertificateAuthority
+        let cert_raw_bytes = String::from("MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLguhzAKBggqhkjOPQQDAzAqMRUwEwYDVQEKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==").as_bytes().to_vec();
+        let new_ca = CertificateAuthority {
+            subject: Some(DistinguishedName {
+                organization: "sigstore.dev".to_string(),
+                common_name: "sigstore".to_string(),
+            }),
+            uri: "https://fulcio_test.sigstore.dev".to_string(),
+            cert_chain: Some(X509CertificateChain {
+                certificates: vec![X509Certificate {
+                    raw_bytes: cert_raw_bytes.clone(),
+                }],
+            }),
+            valid_for: Some(TimeRange {
+                start: Some(Timestamp {
+                    seconds: 1724155691,
+                    nanos: 0,
+                }),
+                end: None,
+            }),
+            operator: "".to_string(),
+        };
+        let result =
+            trust_root.set_target(TargetType::Authority(new_ca), Target::CertificateAuthority);
+        assert!(result.is_ok(), "Failed to add new certificate authority");
+
+        let cert_chain = X509Certificate {
+            raw_bytes: cert_raw_bytes,
+        };
+        assert!(
+            trust_root
+                .trusted_root
+                .certificate_authorities
+                .iter()
+                .any(|ca| {
+                    ca.cert_chain
+                        .as_ref()
+                        .map_or(false, |chain| chain.certificates.contains(&cert_chain))
+                }),
+            "Certificate authority not found before deletion"
+        );
+
+        // Delete the CertificateAuthority by cert_chain
+        let result = trust_root.delete_target(&Target::CertificateAuthority, &cert_chain.raw_bytes);
+        assert!(result.is_ok(), "Failed to delete the certificate authority");
+
+        // Verify the CertificateAuthority was deleted
+        assert!(
+            !trust_root
+                .trusted_root
+                .certificate_authorities
+                .iter()
+                .any(|ca| {
+                    ca.cert_chain
+                        .as_ref()
+                        .map_or(false, |chain| chain.certificates.contains(&cert_chain))
+                }),
+            "Certificate authority was not correctly deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_ctlog() {
+        let cache_dir = None;
+        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+            .await
+            .expect("Failed to create SigstoreTrustRoot");
+
+        // Add a new ctlog
+        let public_key_raw_bytes=String::from("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==").as_bytes().to_vec();
+        let new_ctlog = TransparencyLogInstance {
+            base_url: String::from("https://ctfe.sigstore.dev/test"),
+            hash_algorithm: 256,
+            public_key: Some(PublicKey {
+                raw_bytes: Some(public_key_raw_bytes.clone()),
+                key_details: 256,
+                valid_for: Some(TimeRange {
+                    start: Some(Timestamp {
+                        seconds: 1724155691,
+                        nanos: 0,
+                    }),
+                    end: None,
+                }),
+            }),
+            log_id: None,
+            checkpoint_key_id: Some(LogId {
+                key_id: String::from("CGCS8RhS/2hG0drJ4ScRWcYrBY9wzjSbea8IgY2b3I=")
+                    .as_bytes()
+                    .to_vec(),
+            }),
+            operator: "".to_string(),
+        };
+
+        let result = trust_root.set_target(TargetType::Log(new_ctlog), Target::Ctlog);
+        assert!(result.is_ok(), "Failed to add new Ctlog entry");
+
+        let public_key = PublicKey {
+            raw_bytes: Some(public_key_raw_bytes),
+            key_details: 256,
+            valid_for: Some(TimeRange {
+                start: Some(Timestamp {
+                    seconds: 1724155691,
+                    nanos: 0,
+                }),
+                end: None,
+            }),
+        };
+        assert!(
+            trust_root.trusted_root.ctlogs.iter().any(|ctlog| {
+                ctlog
+                    .public_key
+                    .as_ref()
+                    .map_or(false, |key| key.raw_bytes == public_key.raw_bytes)
+            }),
+            "Ctlog not found before deletion"
+        );
+
+        // Delete the ctlog by public key raw data
+        let result =
+            trust_root.delete_target(&Target::Ctlog, &public_key.raw_bytes.clone().unwrap());
+        assert!(result.is_ok(), "Failed to delete the Ctlog");
+
+        // Verify the ctlog was deleted
+        assert!(
+            !trust_root.trusted_root.ctlogs.iter().any(|ctlog| {
+                ctlog
+                    .public_key
+                    .as_ref()
+                    .map_or(false, |key| key.raw_bytes == public_key.raw_bytes)
+            }),
+            "Ctlog was not correctly deleted"
+        );
+    }
+}

--- a/tuftool/trust_root/prod/root.json
+++ b/tuftool/trust_root/prod/root.json
@@ -1,0 +1,145 @@
+{
+ "signatures": [
+  {
+   "keyid": "6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3",
+   "sig": ""
+  },
+  {
+   "keyid": "e71a54d543835ba86adad9460379c7641fb8726d164ea766801a1c522aba7ea2",
+   "sig": "3045022100b0bcf189ce1b93e7db9649d5be512a1880c0e358870e3933e426c5afb8a4061002206d214bd79b09f458ccc521a290aa960c417014fc16e606f82091b5e31814886a"
+  },
+  {
+   "keyid": "22f4caec6d8e6f9555af66b3d4c3cb06a3bb23fdc7e39c916c61f462e6f52b06",
+   "sig": ""
+  },
+  {
+   "keyid": "61643838125b440b40db6942f5cb5a31c0dc04368316eb2aaa58b95904a58222",
+   "sig": "3045022100a9b9e294ec21b62dfca6a16a19d084182c12572e33d9c4dcab5317fa1e8a459d022069f68e55ea1f95c5a367aac7a61a65757f93da5a006a5f4d1cf995be812d7602"
+  },
+  {
+   "keyid": "a687e5bf4fab82b0ee58d46e05c9535145a2c9afb458f43d42b45ca0fdce2a70",
+   "sig": "30440220781178ec3915cb16aca757d40e28435ac5378d6b487acb111d1eeb339397f79a0220781cce48ae46f9e47b97a8414fcf466a986726a5896c72a0e4aba3162cb826dd"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2025-08-19T14:33:09Z",
+  "keys": {
+   "0c87432c3bf09fd99189fdc32fa5eaedf4e4a5fac7bab73fa04a2e0fc64af6f5": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWRiGr5+j+3J5SsH+Ztr5nE2H2wO7\nBV+nO3s93gLca18qTOzHY1oWyAGDykMSsGTUBSt9D+An0KfKsD2mfSM42Q==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-online-uri": "gcpkms:projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp/cryptoKeyVersions/1"
+   },
+   "22f4caec6d8e6f9555af66b3d4c3cb06a3bb23fdc7e39c916c61f462e6f52b06": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzBzVOmHCPojMVLSI364WiiV8NPrD\n6IgRxVliskz/v+y3JER5mcVGcONliDcWMC5J2lfHmjPNPhb4H7xm8LzfSA==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@santiagotorres"
+   },
+   "61643838125b440b40db6942f5cb5a31c0dc04368316eb2aaa58b95904a58222": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEinikSsAQmYkNeH5eYq/CnIzLaacO\nxlSaawQDOwqKy/tCqxq5xxPSJc21K4WIhs9GyOkKfzueY3GILzcMJZ4cWw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@bobcallaway"
+   },
+   "6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy8XKsmhBYDI8Jc0GwzBxeKax0cm5\nSTKEU65HPFunUn41sT8pi0FjM4IkHz/YUmwmLUO0Wt7lxhj6BkLIK4qYAw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@dlorenc"
+   },
+   "a687e5bf4fab82b0ee58d46e05c9535145a2c9afb458f43d42b45ca0fdce2a70": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0ghrh92Lw1Yr3idGV5WqCtMDB8Cx\n+D8hdC4w2ZLNIplVRoVGLskYa3gheMyOjiJ8kPi15aQ2//7P+oj7UvJPGw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@joshuagl"
+   },
+   "e71a54d543835ba86adad9460379c7641fb8726d164ea766801a1c522aba7ea2": {
+    "keyid_hash_algorithms": [
+     "sha256",
+     "sha512"
+    ],
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEXsz3SZXFb8jMV42j6pJlyjbjR8K\nN3Bwocexq6LMIb5qsWKOQvLN16NUefLc4HswOoumRsVVaajSpQS6fobkRw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@mnm678"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3",
+     "e71a54d543835ba86adad9460379c7641fb8726d164ea766801a1c522aba7ea2",
+     "22f4caec6d8e6f9555af66b3d4c3cb06a3bb23fdc7e39c916c61f462e6f52b06",
+     "61643838125b440b40db6942f5cb5a31c0dc04368316eb2aaa58b95904a58222",
+     "a687e5bf4fab82b0ee58d46e05c9535145a2c9afb458f43d42b45ca0fdce2a70"
+    ],
+    "threshold": 3
+   },
+   "snapshot": {
+    "keyids": [
+     "0c87432c3bf09fd99189fdc32fa5eaedf4e4a5fac7bab73fa04a2e0fc64af6f5"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 3650,
+    "x-tuf-on-ci-signing-period": 365
+   },
+   "targets": {
+    "keyids": [
+     "6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3",
+     "e71a54d543835ba86adad9460379c7641fb8726d164ea766801a1c522aba7ea2",
+     "22f4caec6d8e6f9555af66b3d4c3cb06a3bb23fdc7e39c916c61f462e6f52b06",
+     "61643838125b440b40db6942f5cb5a31c0dc04368316eb2aaa58b95904a58222",
+     "a687e5bf4fab82b0ee58d46e05c9535145a2c9afb458f43d42b45ca0fdce2a70"
+    ],
+    "threshold": 3
+   },
+   "timestamp": {
+    "keyids": [
+     "0c87432c3bf09fd99189fdc32fa5eaedf4e4a5fac7bab73fa04a2e0fc64af6f5"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7,
+    "x-tuf-on-ci-signing-period": 6
+   }
+  },
+  "spec_version": "1.0",
+  "version": 12,
+  "x-tuf-on-ci-expiry-period": 197,
+  "x-tuf-on-ci-signing-period": 46
+ }
+}

--- a/tuftool/trust_root/prod/trusted_root.json
+++ b/tuftool/trust_root/prod/trusted_root.json
@@ -1,0 +1,90 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+  "tlogs": [
+    {
+      "baseUrl": "https://rekor.sigstore.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-01-12T11:53:27.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+      }
+    }
+  ],
+  "certificateAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ=="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2021-03-07T03:20:29.000Z",
+        "end": "2022-12-31T23:59:59.999Z"
+      }
+    },
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="
+          },
+          {
+            "rawBytes": "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      }
+    }
+  ],
+  "ctlogs": [
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/test",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-03-14T00:00:00.000Z",
+          "end": "2022-10-31T23:59:59.999Z"
+        }
+      },
+      "logId": {
+        "keyId": "CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/2022",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-10-20T00:00:00.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4="
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary by Sourcery

Embed Sigstore trust root integration into tuftool by bundling sigstore-rs code under a new feature, updating cargo configuration and dependencies, adjusting CLI behavior for RHTAS commands, and adding comprehensive tests.

New Features:
- Embed Sigstore TUF-based trust root implementation (SigstoreTrustRoot) in tuftool
- Add new 'sigstore-trust-root' feature enabled by default

Enhancements:
- Support fetching and caching Fulcio certificates, Rekor, and CTFE keys via TUF
- Add operator field to RHTAS commands and adjust checkpoint/log ID handling
- Bump and update cargo dependencies (sigstore_protobuf_specs v0.4, prost-types v0.13.5)

Build:
- Add dependencies for sigstore_trust feature (futures-util, regex, tokio-util, pki-types, thiserror, tracing, rstest)
- Enable 'sigstore-trust-root' in default features

Tests:
- Add tests for SigstoreTrustRoot operations, including fetch, update, and delete targets
- Add unit tests for timerange validation