### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tuf-tool

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -20,4 +20,5 @@ LABEL io.k8s.display-name="Tuftool container image for Red Hat Trusted Artifact 
 LABEL io.openshift.tags="Tuftool Trusted Artifact Signer"
 LABEL summary="Provides the Tuftool binary for generating and signing TUF repositories"
 LABEL com.redhat.component="tuftool"
-LABEL name="tuftool"
+LABEL name="rhtas/tuftool-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Enhancements:
- Add name and CPE labels to the TUF tool Dockerfile to enable Clair image lookup in VEX statements