### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tuffer

### DIFF
--- a/Dockerfile.tuffer
+++ b/Dockerfile.tuffer
@@ -23,4 +23,5 @@ LABEL io.k8s.display-name="Tuffer container image for Red Hat Trusted Artifact S
 LABEL io.openshift.tags="Tuffer Trusted Artifact Signer"
 LABEL summary="Provides the tuf-repo-init script for generating an initial trust root for RHTAS"
 LABEL com.redhat.component="tuffer"
-LABEL name="tuffer"
+LABEL name="rhtas/tuffer-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Build:
- Include 'name' and 'cpe' LABELs in Dockerfile.tuffer for Clair compatibility