### PR TITLE
Updating labels

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -21,4 +21,4 @@ LABEL io.openshift.tags="Tuftool Trusted Artifact Signer"
 LABEL summary="Provides the Tuftool binary for generating and signing TUF repositories"
 LABEL com.redhat.component="tuftool"
 LABEL name="rhtas/tuftool-rhel9"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
+

--- a/Dockerfile.tuffer
+++ b/Dockerfile.tuffer
@@ -23,4 +23,4 @@ LABEL io.k8s.display-name="Tuffer container image for Red Hat Trusted Artifact S
 LABEL io.openshift.tags="Tuffer Trusted Artifact Signer"
 LABEL summary="Provides the tuf-repo-init script for generating an initial trust root for RHTAS"
 LABEL com.redhat.component="tuffer"
-LABEL name="tuffer"
+LABEL name="rhtas/tuffer-rhel9"


### PR DESCRIPTION
## Summary by Sourcery

Update image metadata labels in Dockerfile.rh and Dockerfile.tuffer to ensure consistent labeling across Docker builds

Enhancements:
- Standardize and update LABEL instructions in Dockerfile.rh
- Standardize and update LABEL instructions in Dockerfile.tuffer