### PR TITLE
[SECURESIGN-3143] Align trusted_root.json schema with sigstore-go requirements

### DIFF
--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -668,8 +668,8 @@ impl RhtasArgs {
                     key_details: key_details.unwrap(),
                     valid_for: Some(TimeRange { start, end }),
                 }),
-                checkpoint_key_id: Some(LogId { key_id }),
-                log_id: None,
+                log_id: Some(LogId { key_id }),
+                checkpoint_key_id: None,
                 operator: String::new(),
             };
 
@@ -757,8 +757,8 @@ impl RhtasArgs {
                     key_details: key_details.unwrap(),
                     valid_for: Some(TimeRange { start, end }),
                 }),
-                checkpoint_key_id: Some(LogId { key_id }),
-                log_id: None,
+                log_id: Some(LogId { key_id }),
+                checkpoint_key_id: None,
                 operator: String::new(),
             };
 

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -348,15 +348,16 @@ impl SigstoreTrustRoot {
             Target::Ctlog => {
                 if let TargetType::Log(mut ctlog) = new_target {
                     let exists = self.trusted_root.ctlogs.iter().any(|existing_ctlog| {
-                        existing_ctlog.checkpoint_key_id == ctlog.checkpoint_key_id
+                        existing_ctlog.log_id == ctlog.log_id
                             || existing_ctlog.public_key == ctlog.public_key
                     });
 
                     if exists {
-                        if let Some(existing_ctlog) =
-                            self.trusted_root.ctlogs.iter_mut().find(|existing_ctlog| {
-                                existing_ctlog.checkpoint_key_id == ctlog.checkpoint_key_id
-                            })
+                        if let Some(existing_ctlog) = self
+                            .trusted_root
+                            .ctlogs
+                            .iter_mut()
+                            .find(|existing_ctlog| existing_ctlog.log_id == ctlog.log_id)
                         {
                             // If valid_for.start is not set; User wants to expire the target
                             if let Some(valid_for) = &mut ctlog
@@ -400,15 +401,16 @@ impl SigstoreTrustRoot {
             Target::Tlog => {
                 if let TargetType::Log(mut tlog) = new_target {
                     let exists = self.trusted_root.tlogs.iter().any(|existing_tlog| {
-                        existing_tlog.checkpoint_key_id == tlog.checkpoint_key_id
+                        existing_tlog.log_id == tlog.log_id
                             || existing_tlog.public_key == tlog.public_key
                     });
 
                     if exists {
-                        if let Some(existing_tlog) =
-                            self.trusted_root.tlogs.iter_mut().find(|existing_tlog| {
-                                existing_tlog.checkpoint_key_id == tlog.checkpoint_key_id
-                            })
+                        if let Some(existing_tlog) = self
+                            .trusted_root
+                            .tlogs
+                            .iter_mut()
+                            .find(|existing_tlog| existing_tlog.log_id == tlog.log_id)
                         {
                             // If valid_for.start is not set; User wants to expire the target
                             if let Some(valid_for) = &mut tlog
@@ -587,11 +589,11 @@ impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustRoot {
     fn rekor_keys(&self) -> Result<Vec<&[u8]>> {
         let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.tlogs).collect();
 
-        if keys.len() == 1 {
+        if !keys.is_empty() {
             Ok(keys)
         } else {
             Err(SigstoreError::TufMetadataError(
-                "Did not find exactly 1 active Rekor key".into(),
+                "No active Rekor keys".into(),
             ))
         }
     }
@@ -871,8 +873,8 @@ mod tests {
                     end: None,
                 }),
             }),
-            log_id: None,
-            checkpoint_key_id: Some(LogId {
+            checkpoint_key_id: None,
+            log_id: Some(LogId {
                 key_id: String::from("CGCS8RhS/2hG0drJ4ScRWcYrBY9wzjSbea8IgY2b3I=").as_bytes().to_vec(),
             }),
             operator: "".to_string()
@@ -1009,8 +1011,8 @@ mod tests {
                     end: None,
                 }),
             }),
-            log_id: None,
-            checkpoint_key_id: Some(LogId {
+            checkpoint_key_id: None,
+            log_id: Some(LogId {
                 key_id: String::from("CGCS8RhS/2hG0drJ4ScRWcYrBY9wzjSbea8IgY2b3I=")
                     .as_bytes()
                     .to_vec(),

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -66,6 +66,7 @@ pub enum Target {
 #[allow(clippy::unnecessary_map_or)]
 #[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::clone_on_copy)]
+#[allow(deprecated)]
 impl SigstoreTrustRoot {
     // Needed to construct SigstoreTrustRoot from trusted_root.json
     pub fn from_trusted_root(trusted_root: TrustedRoot) -> Self {

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -589,12 +589,12 @@ impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustRoot {
     fn rekor_keys(&self) -> Result<Vec<&[u8]>> {
         let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.tlogs).collect();
 
-        if !keys.is_empty() {
-            Ok(keys)
-        } else {
+        if keys.is_empty() {
             Err(SigstoreError::TufMetadataError(
                 "No active Rekor keys".into(),
             ))
+        } else {
+            Ok(keys)
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Align trusted_root.json schema with sigstore-go requirements by standardizing on log_id over checkpoint_key_id, relaxing Rekor key validation, and synchronizing affected code and tests.

Enhancements:
- Replace checkpoint_key_id matching logic with log_id for CTLog and TLog entries
- Relax Rekor key validation to allow any active key and update its error message

Tests:
- Update test fixtures to use log_id instead of checkpoint_key_id

Chores:
- Update RhtasArgs constructors to set log_id instead of checkpoint_key_id