### PR TITLE
fix: correct licence and user init

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -11,6 +11,9 @@ RUN cd /tmp/tuftool && cargo build --release
 FROM registry.access.redhat.com/ubi9/ubi:latest as deploy
 
 COPY --from=builder /tmp/tuftool/target/release/tuftool /usr/bin/
+COPY licenses/LICENSE-APACHE /licenses/license.txt
+
+USER 65532:65532
 
 ENTRYPOINT ["/usr/bin/tuftool"]
 
@@ -21,4 +24,3 @@ LABEL io.openshift.tags="Tuftool Trusted Artifact Signer"
 LABEL summary="Provides the Tuftool binary for generating and signing TUF repositories"
 LABEL com.redhat.component="tuftool"
 LABEL name="rhtas/tuftool-rhel9"
-

--- a/Dockerfile.tuffer
+++ b/Dockerfile.tuffer
@@ -11,11 +11,12 @@ RUN cd /tmp/tuftool && cargo build --release
 FROM registry.access.redhat.com/ubi9/ubi:latest as deploy
 
 COPY --from=builder /tmp/tuftool/target/release/tuftool /usr/bin/
+COPY licenses/LICENSE-APACHE /licenses/license.txt
 
 COPY rhtas/tuf-repo-init.sh /usr/bin/
 
 ENTRYPOINT ["/usr/bin/tuf-repo-init.sh"]
-USER 1001
+USER 65532:65532
 
 LABEL description ="Tuffer is a utility application used for generating an initial trust root for RHTAS"
 LABEL io.k8s.description="Tuffer is a utility application used for generating an initial trust root for RHTAS"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add Apache license file to container images

- Change user from 1001 to 65532:65532 for security compliance

- Remove trailing whitespace from Dockerfile.rh


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile.rh<br/>Dockerfile.tuffer"] -- "Add Apache license" --> B["licenses/LICENSE-APACHE<br/>copied to /licenses/"]
  A -- "Update user ID" --> C["USER 65532:65532<br/>security compliance"]
  A -- "Cleanup" --> D["Remove trailing<br/>whitespace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.rh</strong><dd><code>Add license and set non-root user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.rh

<ul><li>Add Apache license file copy to <code>/licenses/license.txt</code><br> <li> Set user to <code>65532:65532</code> for non-root execution<br> <li> Remove trailing blank line at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/126/files#diff-91813b1c8262f775f3c15d04def4509b19d405304b7a8ca4cddf8c7c4e24c850">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.tuffer</strong><dd><code>Add license and update user ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.tuffer

<ul><li>Add Apache license file copy to <code>/licenses/license.txt</code><br> <li> Change user from <code>1001</code> to <code>65532:65532</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/126/files#diff-a12844c0a5bcf837a9b468f92c0725acba3de35725c8aca9b18a678b1ffe055e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Add Apache license file to container images, switch to non-root user UID/GID 65532:65532 for security compliance, and clean up trailing whitespace.

Bug Fixes:
- Include Apache license file in Dockerfile.rh and Dockerfile.tuffer to package license in images
- Change container user to UID:GID 65532:65532 for improved security compliance
- Remove trailing whitespace from Dockerfile.rh