### PR TITLE
[SECURESIGN-3181] Add support for signing_config.v0.2.json target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.0",
 ]
 
 [[package]]
@@ -1152,6 +1152,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1916,6 +1928,17 @@ checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4018,6 +4041,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "filetime",
  "futures",
  "futures-core",
  "futures-util",
@@ -4384,6 +4408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,6 +4471,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,11 +4503,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4484,6 +4540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,6 +4556,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4508,10 +4576,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4526,6 +4606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,6 +4622,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4550,6 +4642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4658,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -30,6 +30,7 @@ aws-sdk-kms = "1"
 aws-sdk-ssm = "1"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
 clap = { version = "4", features = ["derive"] }
+filetime = "0.2"
 futures = "0.3"
 hex = "0.4"
 log = "0.4"

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -99,6 +99,13 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to update timestamp for file {:?}: {}", file, source))]
+    FileTouch {
+        file: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Invalid argument combination: {}", msg))]
     InvalidArgumentCombination { msg: String, backtrace: Backtrace },
 

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -6,7 +6,7 @@ use crate::common::UNUSED_URL;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 #[cfg(feature = "sigstore-trust-root")]
-use crate::sigstore_trust::trust::sigstore::{SigstoreTrustRoot, Target, TargetType};
+use crate::sigstore_trust::trust::sigstore::{SigstoreTrustBundle, Target, TargetType};
 use crate::source::parse_key_source;
 use crate::TargetName;
 use chrono::{DateTime, Utc};
@@ -16,21 +16,25 @@ use openssl::nid::Nid;
 use openssl::pkey::PKey;
 use openssl::rsa::Rsa;
 use prost_types::Timestamp;
-use serde_json::from_reader;
 use serde_json::json;
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 use sigstore_protobuf_specs::dev::sigstore::{
     common::v1::{
         DistinguishedName, LogId, PublicKey, TimeRange, X509Certificate, X509CertificateChain,
     },
-    trustroot::v1::{CertificateAuthority, TransparencyLogInstance, TrustedRoot},
+    trustroot::v1::{
+        CertificateAuthority, ServiceConfiguration, SigningConfig, TransparencyLogInstance,
+        TrustedRoot,
+    },
 };
 use snafu::{OptionExt, ResultExt};
 use std::fs::{self, File};
+use std::io::BufReader;
 use std::io::{self, Read};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tough::editor::signed::{PathExists, SignedRepository};
 use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
@@ -216,84 +220,106 @@ impl RhtasArgs {
 
     #[allow(clippy::too_many_lines)]
     async fn update_metadata(&self, mut editor: RepositoryEditor) -> Result<()> {
-        let mut keys = Vec::new();
-        for source in &self.keys {
-            let key_source = parse_key_source(source)?;
-            keys.push(key_source);
-        }
-
-        self.update_repository_metadata(&mut editor)?;
-
         let trusted_root_path = self.outdir.join("targets").join("trusted_root.json");
-        // Create temporary targets/trusted_root.json
-        // check if a <sha256>.trusted_root.json was already created
-        let latest_trusted_root = self.get_latest_trusted_root();
-        if trusted_root_path != latest_trusted_root {
-            fs::copy(latest_trusted_root.clone(), &trusted_root_path).context(
-                error::FileCopySnafu {
-                    src: latest_trusted_root,
-                    destination: trusted_root_path.clone(),
-                },
-            )?;
-        }
+        let signing_config_path = self.outdir.join("targets").join("signing_config.v0.2.json");
 
-        let mut sigstore_trust_root = RhtasArgs::load_trusted_root(&trusted_root_path)?;
+        let result = async {
+            let mut keys = Vec::new();
+            for source in &self.keys {
+                let key_source = parse_key_source(source)?;
+                keys.push(key_source);
+            }
 
-        // If the "remove-<target>-target" argument was passed, remove the targets from the repository.
-        self.delete_targets(&mut editor, &mut sigstore_trust_root)
-            .await?;
+            self.update_repository_metadata(&mut editor)?;
 
-        self.set_all_targets(&mut editor, &mut sigstore_trust_root)
-            .await?;
+            // Create temporary targets/trusted_root.json
+            // check if a <sha256>.trusted_root.json was already created
+            let latest_trusted_root = self.get_latest_trusted_root();
+            if trusted_root_path != latest_trusted_root {
+                fs::copy(latest_trusted_root.clone(), &trusted_root_path).context(
+                    error::FileCopySnafu {
+                        src: latest_trusted_root,
+                        destination: trusted_root_path.clone(),
+                    },
+                )?;
+            }
 
-        // If a `Targets` metadata needs to be updated
-        if self.role.is_some() && self.indir.is_some() {
-            editor
-                .sign_targets_editor(&keys)
+            let latest_signing_config = self.get_latest_signing_config();
+            if latest_signing_config != signing_config_path {
+                fs::copy(latest_signing_config.clone(), &signing_config_path).context(
+                    error::FileCopySnafu {
+                        src: latest_signing_config,
+                        destination: signing_config_path.clone(),
+                    },
+                )?;
+            }
+
+            let mut sigstore_trust_bundle =
+                RhtasArgs::load_trust_bundle(&trusted_root_path, &signing_config_path)?;
+            // If the "remove-<target>-target" argument was passed, remove the targets from the repository.
+            self.delete_targets(&mut editor, &mut sigstore_trust_bundle)
+                .await?;
+
+            self.set_all_targets(&mut editor, &mut sigstore_trust_bundle)
+                .await?;
+
+            // If a `Targets` metadata needs to be updated
+            if self.role.is_some() && self.indir.is_some() {
+                editor
+                    .sign_targets_editor(&keys)
+                    .await
+                    .context(error::DelegationStructureSnafu)?
+                    .update_delegated_targets(
+                        self.role.as_ref().context(error::MissingSnafu {
+                            what: "delegated role",
+                        })?,
+                        self.indir
+                            .as_ref()
+                            .context(error::MissingSnafu {
+                                what: "delegated role metadata url",
+                            })?
+                            .as_str(),
+                    )
+                    .await
+                    .context(error::DelegateeNotFoundSnafu {
+                        role: self.role.as_ref().unwrap().clone(),
+                    })?;
+            }
+            let signed_repo = editor.sign(&keys).await.context(error::SignRepoSnafu)?;
+
+            self.copy_target_files(&signed_repo).await?;
+
+            signed_repo
+                .write(&self.outdir)
                 .await
-                .context(error::DelegationStructureSnafu)?
-                .update_delegated_targets(
-                    self.role.as_ref().context(error::MissingSnafu {
-                        what: "delegated role",
-                    })?,
-                    self.indir
-                        .as_ref()
-                        .context(error::MissingSnafu {
-                            what: "delegated role metadata url",
-                        })?
-                        .as_str(),
-                )
-                .await
-                .context(error::DelegateeNotFoundSnafu {
-                    role: self.role.as_ref().unwrap().clone(),
+                .context(error::WriteRepoSnafu {
+                    directory: &self.outdir,
                 })?;
+
+            Ok::<(), error::Error>(())
         }
+        .await;
 
-        let signed_repo = editor.sign(&keys).await.context(error::SignRepoSnafu)?;
-
-        self.copy_target_files(&signed_repo).await?;
-
-        signed_repo
-            .write(&self.outdir)
-            .await
-            .context(error::WriteRepoSnafu {
-                directory: &self.outdir,
-            })?;
-
-        // delete targets/trusted_root.json
+        // delete targets/trusted_root.json & targets/signing_config.v0.2.json
         if trusted_root_path.exists() {
             fs::remove_file(&trusted_root_path).context(error::FileDeleteSnafu {
                 file: trusted_root_path.clone(),
             })?;
         }
 
-        Ok(())
+        if signing_config_path.exists() {
+            fs::remove_file(&signing_config_path).context(error::FileDeleteSnafu {
+                file: signing_config_path.clone(),
+            })?;
+        }
+
+        result
     }
 
     async fn delete_targets(
         &self,
         editor: &mut RepositoryEditor,
-        sigstore_trust_root: &mut SigstoreTrustRoot,
+        sigstore_trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         for target_name in &self.delete_fulcio_targets {
             editor
@@ -303,7 +329,7 @@ impl RhtasArgs {
                 })?;
             self.remove_target_file(
                 target_name.raw(),
-                sigstore_trust_root,
+                sigstore_trust_bundle,
                 Target::CertificateAuthority,
             )
             .await?;
@@ -315,7 +341,7 @@ impl RhtasArgs {
                 .context(error::RemoveTargetSnafu {
                     name: target_name.raw(),
                 })?;
-            self.remove_target_file(target_name.raw(), sigstore_trust_root, Target::Ctlog)
+            self.remove_target_file(target_name.raw(), sigstore_trust_bundle, Target::Ctlog)
                 .await?;
         }
 
@@ -325,7 +351,7 @@ impl RhtasArgs {
                 .context(error::RemoveTargetSnafu {
                     name: target_name.raw(),
                 })?;
-            self.remove_target_file(target_name.raw(), sigstore_trust_root, Target::Tlog)
+            self.remove_target_file(target_name.raw(), sigstore_trust_bundle, Target::Tlog)
                 .await?;
         }
 
@@ -337,7 +363,7 @@ impl RhtasArgs {
                 })?;
             self.remove_target_file(
                 target_name.raw(),
-                sigstore_trust_root,
+                sigstore_trust_bundle,
                 Target::TimestampAuthority,
             )
             .await?;
@@ -360,22 +386,43 @@ impl RhtasArgs {
         Ok(())
     }
 
-    fn load_trusted_root(trusted_root_path: &PathBuf) -> Result<SigstoreTrustRoot> {
-        if Path::new(&trusted_root_path).exists() {
+    fn load_trust_bundle(
+        trusted_root_path: &PathBuf,
+        signing_config_path: &PathBuf,
+    ) -> Result<SigstoreTrustBundle> {
+        if Path::new(trusted_root_path).exists() {
             let file = File::open(trusted_root_path).context(error::FileOpenSnafu {
                 path: trusted_root_path.clone(),
             })?;
-            let trusted_root: TrustedRoot =
-                from_reader(file).context(error::FileParseJsonSnafu {
+            let trusted_root: TrustedRoot = serde_json::from_reader(BufReader::new(file)).context(
+                error::FileParseJsonSnafu {
                     path: trusted_root_path.clone(),
+                },
+            )?;
+
+            let signing_config = if signing_config_path.exists() {
+                let file = File::open(signing_config_path).context(error::FileOpenSnafu {
+                    path: signing_config_path.clone(),
                 })?;
-            Ok(SigstoreTrustRoot::from_trusted_root(trusted_root))
+                Some(serde_json::from_reader(BufReader::new(file)).context(
+                    error::FileParseJsonSnafu {
+                        path: signing_config_path,
+                    },
+                )?)
+            } else {
+                None
+            };
+
+            Ok(SigstoreTrustBundle::from_trust_bundle(
+                trusted_root,
+                signing_config,
+            ))
         } else {
-            Ok(RhtasArgs::new_trusted_root())
+            Ok(RhtasArgs::new_trust_bundle())
         }
     }
 
-    pub fn new_trusted_root() -> SigstoreTrustRoot {
+    pub fn new_trust_bundle() -> SigstoreTrustBundle {
         let trusted_root = TrustedRoot {
             media_type: "application/vnd.dev.sigstore.trustedroot+json;version=0.1".to_string(),
             tlogs: Vec::new(),
@@ -384,41 +431,66 @@ impl RhtasArgs {
             timestamp_authorities: Vec::new(),
         };
 
-        SigstoreTrustRoot::from_trusted_root(trusted_root)
+        let signing_config = SigningConfig {
+            media_type: "application/vnd.dev.sigstore.signingconfig.v0.2+json".to_string(),
+            ca_urls: Vec::new(),
+            oidc_urls: Vec::new(),
+            rekor_tlog_urls: Vec::new(),
+            tsa_urls: Vec::new(),
+            rekor_tlog_config: Some(ServiceConfiguration {
+                selector: 2,
+                count: 0,
+            }),
+            tsa_config: Some(ServiceConfiguration {
+                selector: 2,
+                count: 0,
+            }),
+        };
+
+        SigstoreTrustBundle::from_trust_bundle(trusted_root, Some(signing_config))
     }
 
     async fn set_all_targets(
         &self,
         editor: &mut RepositoryEditor,
-        sigstore_trust_root: &mut SigstoreTrustRoot,
+        sigstore_trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         // If the "set-fulcio-target" argument was passed, build a target
         // and add it to the repository.
-        self.set_fulcio_target(editor, sigstore_trust_root).await?;
+        self.set_fulcio_target(editor, sigstore_trust_bundle)
+            .await?;
 
         // If the "set-ctlog-target" argument was passed, build a target
         // and add it to the repository.
-        self.set_ctlog_target(editor, sigstore_trust_root).await?;
+        self.set_ctlog_target(editor, sigstore_trust_bundle).await?;
 
         // If the "set-rekor-target" argument was passed, build a target
         // and add it to the repository.
-        self.set_rekor_target(editor, sigstore_trust_root).await?;
+        self.set_rekor_target(editor, sigstore_trust_bundle).await?;
 
         // If the "set-tsa-target" argument was passed, build a target
         // and add it to the repository.
-        self.set_tsa_target(editor, sigstore_trust_root).await?;
+        self.set_tsa_target(editor, sigstore_trust_bundle).await?;
 
         // Save then set trust_root
         let trusted_root_path = self.outdir.join("targets").join("trusted_root.json");
-        match SigstoreTrustRoot::save_to_file(
-            sigstore_trust_root,
-            trusted_root_path.clone().as_path(),
-        ) {
-            Ok(()) => {}
-            Err(e) => {
-                eprintln!("Error saving to file: {e}");
-            }
-        }
+        sigstore_trust_bundle
+            .save_trusted_root_to_file(&trusted_root_path)
+            .map_err(|e| error::Error::FileOpen {
+                source: std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+                path: trusted_root_path.clone(),
+                backtrace: snafu::Backtrace::new(),
+            })?;
+
+        let signing_config_path = self.outdir.join("targets").join("signing_config.v0.2.json");
+        sigstore_trust_bundle
+            .save_signing_config_to_file(&signing_config_path)
+            .map_err(|e| error::Error::FileOpen {
+                source: std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+                path: signing_config_path.clone(),
+                backtrace: snafu::Backtrace::new(),
+            })?;
+
         self.set_trust_root_target(editor).await?;
         Ok(())
     }
@@ -451,6 +523,36 @@ impl RhtasArgs {
                 .await
                 .context(error::LinkTargetsSnafu {
                     indir: &trusted_root_path,
+                    outdir: targets_outdir,
+                })?;
+        }
+
+        // Handle signing_config.v0.2.json
+        let signing_config_path = self.outdir.join("targets").join("signing_config.v0.2.json");
+        if fs::metadata(&signing_config_path).is_ok() {
+            let resolved_signing_config_path = if self.follow {
+                tokio::fs::canonicalize(&signing_config_path)
+                    .await
+                    .context(error::ResolveSymlinkSnafu {
+                        path: &signing_config_path,
+                    })?
+            } else {
+                signing_config_path.clone()
+            };
+            let target_name =
+                TargetName::new("signing_config.v0.2.json").context(error::RemoveTargetSnafu {
+                    name: "signing_config.v0.2.json".to_string(),
+                })?;
+            signed_repo
+                .copy_target(
+                    &resolved_signing_config_path,
+                    targets_outdir,
+                    self.target_path_exists,
+                    Some(&target_name),
+                )
+                .await
+                .context(error::LinkTargetsSnafu {
+                    indir: &signing_config_path,
                     outdir: targets_outdir,
                 })?;
         }
@@ -501,24 +603,33 @@ impl RhtasArgs {
 
     async fn set_trust_root_target(&self, editor: &mut RepositoryEditor) -> Result<()> {
         let trusted_root_path = self.outdir.join("targets").join("trusted_root.json");
-        // Check if the trusted_root.json exists
         if tokio::fs::metadata(&trusted_root_path).await.is_ok() {
             let mut trusted_root_target = build_targets(&trusted_root_path, self.follow).await?;
-            // Add trusted_root as a target
             if let Some((target_name, target)) = trusted_root_target.iter_mut().next() {
-                // Add the trusted root target
                 editor
                     .add_target(target_name.clone(), target.clone())
                     .context(error::DelegationStructureSnafu)?;
             }
         }
+
+        let signing_config_path = self.outdir.join("targets").join("signing_config.v0.2.json");
+        if tokio::fs::metadata(&signing_config_path).await.is_ok() {
+            let mut signing_config_target =
+                build_targets(&signing_config_path, self.follow).await?;
+            if let Some((target_name, target)) = signing_config_target.iter_mut().next() {
+                editor
+                    .add_target(target_name.clone(), target.clone())
+                    .context(error::DelegationStructureSnafu)?;
+            }
+        }
+
         Ok(())
     }
 
     async fn set_fulcio_target(
         &self,
         editor: &mut RepositoryEditor,
-        trusted_root: &mut SigstoreTrustRoot,
+        trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         if let Some(ref fulcio_target_path) = self.fulcio_target {
             let mut fulcio_target = build_targets(fulcio_target_path, self.follow).await?;
@@ -582,12 +693,12 @@ impl RhtasArgs {
                 operator: String::new(),
             };
 
-            match trusted_root
+            match trust_bundle
                 .set_target(TargetType::Authority(new_ca), Target::CertificateAuthority)
             {
                 Ok(()) => {}
                 Err(e) => {
-                    eprintln!("Failed to set target: {e:?} in trusted_root");
+                    eprintln!("Failed to set target: {e:?} in trust_bundle");
                 }
             }
         }
@@ -597,7 +708,7 @@ impl RhtasArgs {
     async fn set_ctlog_target(
         &self,
         editor: &mut RepositoryEditor,
-        trusted_root: &mut SigstoreTrustRoot,
+        trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         if let Some(ref ctlog_target_path) = self.ctlog_target {
             let mut ctlog_target = build_targets(ctlog_target_path, self.follow).await?;
@@ -673,10 +784,10 @@ impl RhtasArgs {
                 operator: String::new(),
             };
 
-            match trusted_root.set_target(TargetType::Log(new_ctlog), Target::Ctlog) {
+            match trust_bundle.set_target(TargetType::Log(new_ctlog), Target::Ctlog) {
                 Ok(()) => {}
                 Err(e) => {
-                    eprintln!("Failed to set target: {e:?} in trusted_root");
+                    eprintln!("Failed to set target: {e:?} in trust_bundle");
                 }
             }
         }
@@ -686,7 +797,7 @@ impl RhtasArgs {
     async fn set_rekor_target(
         &self,
         editor: &mut RepositoryEditor,
-        trusted_root: &mut SigstoreTrustRoot,
+        trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         if let Some(ref rekor_target_path) = self.rekor_target {
             let mut rekor_target = build_targets(rekor_target_path, self.follow).await?;
@@ -762,10 +873,10 @@ impl RhtasArgs {
                 operator: String::new(),
             };
 
-            match trusted_root.set_target(TargetType::Log(new_tlog), Target::Tlog) {
+            match trust_bundle.set_target(TargetType::Log(new_tlog), Target::Tlog) {
                 Ok(()) => {}
                 Err(e) => {
-                    eprintln!("Failed to set target: {e:?} in trusted_root");
+                    eprintln!("Failed to set target: {e:?} in trust_bundle");
                 }
             }
         }
@@ -775,7 +886,7 @@ impl RhtasArgs {
     async fn set_tsa_target(
         &self,
         editor: &mut RepositoryEditor,
-        trusted_root: &mut SigstoreTrustRoot,
+        trust_bundle: &mut SigstoreTrustBundle,
     ) -> Result<()> {
         if let Some(ref tsa_target_path) = self.tsa_target {
             let mut tsa_target = build_targets(tsa_target_path, self.follow).await?;
@@ -839,12 +950,12 @@ impl RhtasArgs {
                 operator: String::new(),
             };
 
-            match trusted_root
+            match trust_bundle
                 .set_target(TargetType::Authority(new_tsa), Target::TimestampAuthority)
             {
                 Ok(()) => {}
                 Err(e) => {
-                    eprintln!("Failed to set target: {e:?} in trusted_root");
+                    eprintln!("Failed to set target: {e:?} in trust_bundle");
                 }
             }
         }
@@ -854,7 +965,7 @@ impl RhtasArgs {
     async fn remove_target_file(
         &self,
         target_name: &str,
-        sigstore_trust_root: &mut SigstoreTrustRoot,
+        sigstore_trust_bundle: &mut SigstoreTrustBundle,
         target_type: Target,
     ) -> Result<()> {
         let targets_dir = self.outdir.join("targets");
@@ -890,16 +1001,30 @@ impl RhtasArgs {
                     })?;
 
                 // Remove target file
+                // Used by delete_signing_config_target
+                let target_uri =
+                    sigstore_trust_bundle.get_uri_for_target(&target_type, &identifier[0]);
+
                 tokio::fs::remove_file(&file_path)
                     .await
                     .context(error::RemoveTargetPathSnafu {
                         path: file_path.clone(),
                     })?;
                 // Remove target from TrustedRoot
-                match sigstore_trust_root.delete_target(&target_type, &identifier[0]) {
+                match sigstore_trust_bundle.delete_target(&target_type, &identifier[0]) {
                     Ok(()) => {}
                     Err(e) => {
                         eprintln!("Failed to delete target: {e:?} from trusted_root");
+                    }
+                }
+
+                // Remove target config from SigningConfig
+                if let Some(uri) = target_uri {
+                    match sigstore_trust_bundle.delete_signing_config_target(&target_type, &uri) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            eprintln!("Failed to delete {uri} from signing_config: {e:?}");
+                        }
                     }
                 }
             }
@@ -1157,37 +1282,101 @@ impl RhtasArgs {
     }
 
     fn get_latest_trusted_root(&self) -> PathBuf {
-        let targets_dir = self.outdir.join("targets");
-        let mut sha256_trusted_root_files: Vec<PathBuf> = Vec::new();
-        if let Ok(entries) = fs::read_dir(&targets_dir) {
+        let repo_dir = &self.outdir;
+        let targets_dir = repo_dir.join("targets");
+
+        // Find the latest target metadata file: N.targets.json
+        let mut latest_targets: Option<PathBuf> = None;
+        let mut latest_version: u64 = 0;
+
+        if let Ok(entries) = fs::read_dir(repo_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if let Some(extension) = path.extension() {
-                    if extension == "json"
-                        && path
-                            .file_name()
-                            .unwrap_or_default()
-                            .to_string_lossy()
-                            .ends_with(".trusted_root.json")
-                    {
-                        sha256_trusted_root_files.push(path);
+                if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+                    if let Some(version_str) = file_name.strip_suffix(".targets.json") {
+                        if let Ok(version) = version_str.parse::<u64>() {
+                            if version > latest_version {
+                                latest_version = version;
+                                latest_targets = Some(path);
+                            }
+                        }
                     }
                 }
             }
         }
-        // get the latest file based on update time
-        if !sha256_trusted_root_files.is_empty() {
-            let latest_trusted_root = sha256_trusted_root_files.into_iter().max_by_key(|path| {
-                fs::metadata(path)
-                    .and_then(|metadata| metadata.modified())
-                    .map(|time| time.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO))
-                    .unwrap_or(Duration::ZERO)
-            });
-            if let Some(latest_file) = latest_trusted_root {
-                return latest_file;
+
+        // Parse latest targets.json to identify latest trusted_root reference
+        if let Some(targets_path) = latest_targets {
+            if let Ok(data) = fs::read_to_string(&targets_path) {
+                if let Ok(json) = serde_json::from_str::<Value>(&data) {
+                    if let Some(hash_val) = json
+                        .get("signed")
+                        .and_then(|s| s.get("targets"))
+                        .and_then(|t| t.get("trusted_root.json"))
+                        .and_then(|t| t.get("hashes"))
+                        .and_then(|h| h.get("sha256"))
+                        .and_then(|v| v.as_str())
+                    {
+                        let hashed_path = targets_dir.join(format!("{hash_val}.trusted_root.json"));
+                        if hashed_path.exists() {
+                            return hashed_path;
+                        }
+                    }
+                }
             }
         }
-        // return the default "trusted_root.json" path
+
+        // fallback: return the default "trusted_root.json" path
         targets_dir.join("trusted_root.json")
+    }
+
+    fn get_latest_signing_config(&self) -> PathBuf {
+        let repo_dir = &self.outdir;
+        let targets_dir = repo_dir.join("targets");
+
+        // Find the latest target metadata file: N.targets.json
+        let mut latest_targets: Option<PathBuf> = None;
+        let mut latest_version: u64 = 0;
+
+        if let Ok(entries) = fs::read_dir(repo_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+                    if let Some(version_str) = file_name.strip_suffix(".targets.json") {
+                        if let Ok(version) = version_str.parse::<u64>() {
+                            if version > latest_version {
+                                latest_version = version;
+                                latest_targets = Some(path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Parse latest targets.json to identify latest signing_config reference
+        if let Some(targets_path) = latest_targets {
+            if let Ok(data) = fs::read_to_string(&targets_path) {
+                if let Ok(json) = serde_json::from_str::<Value>(&data) {
+                    if let Some(hash_val) = json
+                        .get("signed")
+                        .and_then(|s| s.get("targets"))
+                        .and_then(|t| t.get("signing_config.v0.2.json"))
+                        .and_then(|t| t.get("hashes"))
+                        .and_then(|h| h.get("sha256"))
+                        .and_then(|v| v.as_str())
+                    {
+                        let hashed_path =
+                            targets_dir.join(format!("{hash_val}.signing_config.v0.2.json"));
+                        if hashed_path.exists() {
+                            return hashed_path;
+                        }
+                    }
+                }
+            }
+        }
+
+        // fallback: return the default "signing_config.v0.2.json" path
+        targets_dir.join("signing_config.v0.2.json")
     }
 }

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -15,7 +15,7 @@
 
 //! Helper Structs to interact with the Sigstore TUF repository.
 //!
-//! The main interaction point is [`SigstoreTrustRoot`], which fetches Rekor's
+//! The main interaction point is [`SigstoreTrustBundle`], which fetches Rekor's
 //! public key and Fulcio's certificate.
 //!
 //! These can later be given to [`cosign::ClientBuilder`](crate::cosign::ClientBuilder)
@@ -28,7 +28,10 @@ use tokio_util::bytes::BytesMut;
 use pki_types::CertificateDer;
 use sigstore_protobuf_specs::dev::sigstore::{
     common::v1::TimeRange,
-    trustroot::v1::{CertificateAuthority, TransparencyLogInstance, TrustedRoot},
+    trustroot::v1::{
+        CertificateAuthority, Service, ServiceConfiguration, SigningConfig,
+        TransparencyLogInstance, TrustedRoot,
+    },
 };
 use std::str;
 use tough::TargetName;
@@ -42,14 +45,16 @@ use std::convert::TryInto;
 
 /// Securely fetches Rekor public key and Fulcio certificates from Sigstore's TUF repository.
 #[derive(Debug)]
-pub struct SigstoreTrustRoot {
+pub struct SigstoreTrustBundle {
     trusted_root: TrustedRoot,
+    signing_config: Option<SigningConfig>,
 }
 
 pub enum TargetType {
     Authority(CertificateAuthority),
     Log(TransparencyLogInstance),
 }
+#[derive(Debug)]
 pub enum Target {
     CertificateAuthority,
     TimestampAuthority,
@@ -67,10 +72,16 @@ pub enum Target {
 #[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::clone_on_copy)]
 #[allow(deprecated)]
-impl SigstoreTrustRoot {
-    // Needed to construct SigstoreTrustRoot from trusted_root.json
-    pub fn from_trusted_root(trusted_root: TrustedRoot) -> Self {
-        SigstoreTrustRoot { trusted_root }
+impl SigstoreTrustBundle {
+    // Needed to construct SigstoreTrustBundle from trusted_root.json & signing_config.v0.2.json
+    pub fn from_trust_bundle(
+        trusted_root: TrustedRoot,
+        signing_config: Option<SigningConfig>,
+    ) -> Self {
+        SigstoreTrustBundle {
+            trusted_root,
+            signing_config,
+        }
     }
     /// Constructs a new trust root from a [`tough::Repository`].
     async fn from_tough(
@@ -82,7 +93,19 @@ impl SigstoreTrustRoot {
             serde_json::from_slice(&data[..])?
         };
 
-        Ok(Self { trusted_root })
+        let signing_config = {
+            let data =
+                Self::fetch_target(repository, checkout_dir, "signing_config.v0.2.json").await;
+            match data {
+                Ok(data) => Some(serde_json::from_slice(&data[..])?),
+                Err(_) => None, // SigningConfig is optional
+            }
+        };
+
+        Ok(Self {
+            trusted_root,
+            signing_config,
+        })
     }
 
     /// Constructs a new trust root backed by the Sigstore Public Good Instance.
@@ -183,11 +206,25 @@ impl SigstoreTrustRoot {
             .map(|cert| cert.raw_bytes.as_slice())
     }
     /// Save the trusted root to a file
-    pub fn save_to_file(&self, file_path: &Path) -> Result<()> {
+    pub fn save_trusted_root_to_file(&self, file_path: &Path) -> Result<()> {
         let json = serde_json::to_string_pretty(&self.trusted_root)
             .map_err(|e| SigstoreError::SerializationError(e.to_string()))?;
 
         std::fs::write(file_path, json).map_err(SigstoreError::from)
+    }
+
+    /// Save the signing config to a file
+    pub fn save_signing_config_to_file(&self, file_path: &Path) -> Result<()> {
+        if let Some(signing_config) = &self.signing_config {
+            let json = serde_json::to_string_pretty(signing_config)
+                .map_err(|e| SigstoreError::SerializationError(e.to_string()))?;
+            std::fs::write(file_path, json).map_err(SigstoreError::from)?;
+            Ok(())
+        } else {
+            Err(SigstoreError::UnexpectedError(
+                "No signing_config available to save".to_string(),
+            ))
+        }
     }
 
     // SECURESIGN-2010
@@ -212,7 +249,7 @@ impl SigstoreTrustRoot {
                             .iter()
                             .filter(|cert| {
                                 let corrupted =
-                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                    SigstoreTrustBundle::is_corrupted_raw_bytes(&cert.raw_bytes);
                                 !corrupted
                             })
                             .cloned()
@@ -230,7 +267,7 @@ impl SigstoreTrustRoot {
                             .iter()
                             .filter(|cert| {
                                 let corrupted =
-                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                    SigstoreTrustBundle::is_corrupted_raw_bytes(&cert.raw_bytes);
                                 !corrupted
                             })
                             .cloned()
@@ -245,7 +282,7 @@ impl SigstoreTrustRoot {
                     let corrupted = ctlog.public_key.as_ref().map_or(false, |key| {
                         key.raw_bytes
                             .as_ref()
-                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                            .map_or(false, |rb| SigstoreTrustBundle::is_corrupted_raw_bytes(rb))
                     });
                     !corrupted
                 });
@@ -255,7 +292,7 @@ impl SigstoreTrustRoot {
                     let corrupted = tlog.public_key.as_ref().map_or(false, |key| {
                         key.raw_bytes
                             .as_ref()
-                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                            .map_or(false, |rb| SigstoreTrustBundle::is_corrupted_raw_bytes(rb))
                     });
                     !corrupted
                 });
@@ -299,8 +336,42 @@ impl SigstoreTrustRoot {
                                 }
                             }
                         }
-                        self.trusted_root.certificate_authorities.push(ca);
+                        self.trusted_root.certificate_authorities.push(ca.clone());
                     }
+                    // Update SigningConfig ca_urls
+                    let signing_config = self.signing_config.get_or_insert_with(|| SigningConfig {
+                        media_type: "application/vnd.dev.sigstore.signingconfig.v0.2+json"
+                            .to_string(),
+                        ca_urls: Vec::new(),
+                        oidc_urls: Vec::new(),
+                        rekor_tlog_urls: Vec::new(),
+                        tsa_urls: Vec::new(),
+                        rekor_tlog_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                        tsa_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                    });
+
+                    let uri = ca.clone().uri;
+                    let operator = if ca.clone().operator.clone().is_empty() {
+                        "sigstore.dev".to_string()
+                    } else {
+                        ca.clone().operator
+                    };
+                    let valid_for = ca.clone().valid_for;
+                    signing_config
+                        .ca_urls
+                        .retain(|service| service.url != ca.uri);
+                    signing_config.ca_urls.push(Service {
+                        url: uri,
+                        major_api_version: 1,
+                        valid_for,
+                        operator,
+                    });
                 } else {
                     return Err(SigstoreError::UnexpectedError(
                         "Expected a CertificateAuthority, but got a different target.".to_string(),
@@ -338,8 +409,42 @@ impl SigstoreTrustRoot {
                                 }
                             }
                         }
-                        self.trusted_root.timestamp_authorities.push(tsa);
+                        self.trusted_root.timestamp_authorities.push(tsa.clone());
                     }
+                    // Update SigningConfig ca_urls
+                    let signing_config = self.signing_config.get_or_insert_with(|| SigningConfig {
+                        media_type: "application/vnd.dev.sigstore.signingconfig.v0.2+json"
+                            .to_string(),
+                        ca_urls: Vec::new(),
+                        oidc_urls: Vec::new(),
+                        rekor_tlog_urls: Vec::new(),
+                        tsa_urls: Vec::new(),
+                        rekor_tlog_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                        tsa_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                    });
+
+                    let uri = tsa.clone().uri;
+                    let operator = if tsa.clone().operator.clone().is_empty() {
+                        "sigstore.dev".to_string()
+                    } else {
+                        tsa.clone().operator
+                    };
+                    let valid_for = tsa.clone().valid_for;
+                    signing_config
+                        .tsa_urls
+                        .retain(|service| service.url != tsa.uri);
+                    signing_config.tsa_urls.push(Service {
+                        url: uri,
+                        major_api_version: 1,
+                        valid_for,
+                        operator,
+                    });
                 } else {
                     return Err(SigstoreError::UnexpectedError(
                         "Expected a TimestampAuthority, but got a different target.".to_string(),
@@ -444,8 +549,46 @@ impl SigstoreTrustRoot {
                                 }
                             }
                         }
-                        self.trusted_root.tlogs.push(tlog);
+                        self.trusted_root.tlogs.push(tlog.clone());
                     }
+                    // Update SigningConfig rekor_tlog_urls
+                    let signing_config = self.signing_config.get_or_insert_with(|| SigningConfig {
+                        media_type: "application/vnd.dev.sigstore.signingconfig.v0.2+json"
+                            .to_string(),
+                        ca_urls: Vec::new(),
+                        oidc_urls: Vec::new(),
+                        rekor_tlog_urls: Vec::new(),
+                        tsa_urls: Vec::new(),
+                        rekor_tlog_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                        tsa_config: Some(ServiceConfiguration {
+                            selector: 2,
+                            count: 0,
+                        }),
+                    });
+
+                    let base_url = tlog.clone().base_url;
+                    let operator = if tlog.clone().operator.is_empty() {
+                        "sigstore.dev".to_string()
+                    } else {
+                        tlog.clone().operator
+                    };
+                    let valid_for = tlog
+                        .clone()
+                        .public_key
+                        .as_ref()
+                        .and_then(|pk| pk.valid_for.clone());
+                    signing_config
+                        .rekor_tlog_urls
+                        .retain(|service| service.url != tlog.base_url);
+                    signing_config.rekor_tlog_urls.push(Service {
+                        url: base_url,
+                        major_api_version: 1,
+                        valid_for,
+                        operator,
+                    });
                 } else {
                     return Err(SigstoreError::UnexpectedError(
                         "Expected a Tlog, but got a different target.".to_string(),
@@ -469,7 +612,7 @@ impl SigstoreTrustRoot {
                             .iter()
                             .filter(|cert| {
                                 let corrupted =
-                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                    SigstoreTrustBundle::is_corrupted_raw_bytes(&cert.raw_bytes);
                                 !corrupted
                             })
                             .cloned()
@@ -487,7 +630,7 @@ impl SigstoreTrustRoot {
                             .iter()
                             .filter(|cert| {
                                 let corrupted =
-                                    SigstoreTrustRoot::is_corrupted_raw_bytes(&cert.raw_bytes);
+                                    SigstoreTrustBundle::is_corrupted_raw_bytes(&cert.raw_bytes);
                                 !corrupted
                             })
                             .cloned()
@@ -502,7 +645,7 @@ impl SigstoreTrustRoot {
                     let corrupted = ctlog.public_key.as_ref().map_or(false, |key| {
                         key.raw_bytes
                             .as_ref()
-                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                            .map_or(false, |rb| SigstoreTrustBundle::is_corrupted_raw_bytes(rb))
                     });
                     !corrupted
                 });
@@ -512,7 +655,7 @@ impl SigstoreTrustRoot {
                     let corrupted = tlog.public_key.as_ref().map_or(false, |key| {
                         key.raw_bytes
                             .as_ref()
-                            .map_or(false, |rb| SigstoreTrustRoot::is_corrupted_raw_bytes(rb))
+                            .map_or(false, |rb| SigstoreTrustBundle::is_corrupted_raw_bytes(rb))
                     });
                     !corrupted
                 });
@@ -559,9 +702,77 @@ impl SigstoreTrustRoot {
         }
         Ok(())
     }
+
+    // Delete a target config from the SigningConfig by its uri as identifier:
+    pub fn delete_signing_config_target(&mut self, target_type: &Target, uri: &str) -> Result<()> {
+        let Some(signing_config) = &mut self.signing_config else {
+            return Ok(());
+        };
+
+        match target_type {
+            Target::CertificateAuthority => {
+                signing_config.ca_urls.retain(|svc| svc.url != uri);
+            }
+            Target::Tlog => {
+                signing_config.rekor_tlog_urls.retain(|svc| svc.url != uri);
+            }
+            Target::TimestampAuthority => {
+                signing_config.tsa_urls.retain(|svc| svc.url != uri);
+            }
+            Target::Ctlog => {
+                // SigningConfig doesn’t include CTlog
+            }
+        }
+        Ok(())
+    }
+
+    // Get the URI associated with a given target identifier (certificate or public key)
+    // by inspecting the TrustedRoot.
+    pub fn get_uri_for_target(&self, target_type: &Target, identifier: &[u8]) -> Option<String> {
+        match target_type {
+            Target::CertificateAuthority => {
+                for ca in &self.trusted_root.certificate_authorities {
+                    if let Some(chain) = &ca.cert_chain {
+                        for cert in &chain.certificates {
+                            if cert.raw_bytes == identifier && !ca.uri.is_empty() {
+                                return Some(ca.uri.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            Target::Tlog => {
+                for tlog in &self.trusted_root.tlogs {
+                    if let Some(key) = &tlog.public_key {
+                        if let Some(raw_bytes) = &key.raw_bytes {
+                            if raw_bytes == identifier && !tlog.base_url.is_empty() {
+                                return Some(tlog.base_url.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            Target::TimestampAuthority => {
+                for tsa in &self.trusted_root.timestamp_authorities {
+                    if let Some(chain) = &tsa.cert_chain {
+                        for cert in &chain.certificates {
+                            if cert.raw_bytes == identifier && !tsa.uri.is_empty() {
+                                return Some(tsa.uri.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            Target::Ctlog => {
+                // SigningConfig doesn’t contain CT logs
+                return None;
+            }
+        }
+        None
+    }
 }
 
-impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustRoot {
+impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustBundle {
     /// Fetch Fulcio certificates from the given TUF repository or reuse
     /// the local cache if its contents are not outdated.
     ///
@@ -656,7 +867,7 @@ mod tests {
     use std::time::SystemTime;
     use tempfile::TempDir;
 
-    fn verify(root: &SigstoreTrustRoot, cache_dir: Option<&Path>) {
+    fn verify(root: &SigstoreTrustBundle, cache_dir: Option<&Path>) {
         if let Some(cache_dir) = cache_dir {
             assert!(
                 cache_dir.join("trusted_root.json").exists(),
@@ -683,10 +894,10 @@ mod tests {
         TempDir::new().expect("cannot create temp cache dir")
     }
 
-    async fn trust_root(cache: Option<&Path>) -> SigstoreTrustRoot {
-        SigstoreTrustRoot::new(cache)
+    async fn trust_root(cache: Option<&Path>) -> SigstoreTrustBundle {
+        SigstoreTrustBundle::new(cache)
             .await
-            .expect("failed to construct SigstoreTrustRoot")
+            .expect("failed to construct SigstoreTrustBundle")
     }
 
     #[rstest]
@@ -748,9 +959,9 @@ mod tests {
     #[tokio::test]
     async fn test_add_new_certificate_authority() {
         let cache_dir = None;
-        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+        let mut trust_root = SigstoreTrustBundle::new(cache_dir)
             .await
-            .expect("Failed to create SigstoreTrustRoot");
+            .expect("Failed to create SigstoreTrustBundle");
         let initial_length = trust_root.trusted_root.certificate_authorities.len();
         let new_ca = CertificateAuthority {
             subject: Some(DistinguishedName {
@@ -811,9 +1022,9 @@ mod tests {
     #[tokio::test]
     async fn test_update_certificate_authority() {
         let cache_dir = None;
-        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+        let mut trust_root = SigstoreTrustBundle::new(cache_dir)
             .await
-            .expect("Failed to create SigstoreTrustRoot");
+            .expect("Failed to create SigstoreTrustBundle");
         let initial_length = trust_root.trusted_root.certificate_authorities.len();
 
         // Update the last certificate authority
@@ -856,9 +1067,9 @@ mod tests {
     #[tokio::test]
     async fn test_add_new_ctlog() {
         let cache_dir = None;
-        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+        let mut trust_root = SigstoreTrustBundle::new(cache_dir)
             .await
-            .expect("Failed to create SigstoreTrustRoot");
+            .expect("Failed to create SigstoreTrustBundle");
         let initial_length = trust_root.trusted_root.ctlogs.len();
         let new_ctlog = TransparencyLogInstance {
             base_url: String::from("https://ctfe.sigstore.dev/test"),
@@ -924,9 +1135,9 @@ mod tests {
     #[tokio::test]
     async fn test_delete_certificate_authority() {
         let cache_dir = None;
-        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+        let mut trust_root = SigstoreTrustBundle::new(cache_dir)
             .await
-            .expect("Failed to create SigstoreTrustRoot");
+            .expect("Failed to create SigstoreTrustBundle");
 
         // Add a new CertificateAuthority
         let cert_raw_bytes = String::from("MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLguhzAKBggqhkjOPQQDAzAqMRUwEwYDVQEKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==").as_bytes().to_vec();
@@ -992,9 +1203,9 @@ mod tests {
     #[tokio::test]
     async fn test_delete_ctlog() {
         let cache_dir = None;
-        let mut trust_root = SigstoreTrustRoot::new(cache_dir)
+        let mut trust_root = SigstoreTrustBundle::new(cache_dir)
             .await
-            .expect("Failed to create SigstoreTrustRoot");
+            .expect("Failed to create SigstoreTrustBundle");
 
         // Add a new ctlog
         let public_key_raw_bytes=String::from("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==").as_bytes().to_vec();

--- a/tuftool/tests/rhtas_command.rs
+++ b/tuftool/tests/rhtas_command.rs
@@ -128,7 +128,7 @@ async fn rhtas_command_add_new_target() {
     .unwrap();
 
     // Ensure all the targets (new and existing) are accounted for
-    assert_eq!(repo.targets().signed.targets.len(), 5);
+    assert_eq!(repo.targets().signed.targets.len(), 6);
 
     // Ensure we can read the newly added targets
     let ctfe = TargetName::new("ctfe.pub").unwrap();
@@ -201,7 +201,7 @@ async fn rhtas_command_update_target() {
     .unwrap();
 
     // Ensure all the targets (new and existing) are accounted for
-    assert_eq!(repo.targets().signed.targets.len(), 5);
+    assert_eq!(repo.targets().signed.targets.len(), 6);
 
     // // Ensure we can read the newly added targets
     let ctfe = TargetName::new("ctfe.pub").unwrap();
@@ -261,7 +261,7 @@ async fn rhtas_command_update_target() {
     );
 
     // Ensure targets count is unchanged
-    assert_eq!(repo.targets().signed.targets.len(), 5);
+    assert_eq!(repo.targets().signed.targets.len(), 6);
 
     // Revert the target file content to its original state.
     let target_input = fs::File::create(new_targets_input_dir.clone());
@@ -324,7 +324,7 @@ async fn rhtas_command_delete_target() {
     .unwrap();
 
     // Ensure all the targets (new and existing) are accounted for
-    assert_eq!(repo.targets().signed.targets.len(), 5);
+    assert_eq!(repo.targets().signed.targets.len(), 6);
 
     // Delete the target
     Command::cargo_bin("tuftool")
@@ -356,7 +356,7 @@ async fn rhtas_command_delete_target() {
     .unwrap();
 
     // Ensure that one target has been removed
-    assert_eq!(repo.targets().signed.targets.len(), 4);
+    assert_eq!(repo.targets().signed.targets.len(), 5);
 
     // Ensure that the target was removed from repository
     let ctfe = TargetName::new("ctfe.pub").unwrap();

--- a/tuftool/tests/update_rhtas_command.rs
+++ b/tuftool/tests/update_rhtas_command.rs
@@ -4,13 +4,12 @@
 mod test_utils;
 
 use crate::test_utils::days;
-use assert_cmd::assert::Assert;
 use assert_cmd::Command;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use std::path::Path;
 use tempfile::TempDir;
 use test_utils::dir_url;
-use tough::{RepositoryLoader, TargetName};
+use tough::RepositoryLoader;
 
 fn create_repo<P: AsRef<Path>>(repo_dir: P) {
     let timestamp_expiration = Utc::now().checked_add_signed(days(1)).unwrap();


### PR DESCRIPTION
### **PR Type**
Feature + Enhancement


___

### **Description**
- Add support for `signing_config.v0.2.json` target file handling

- Rename `SigstoreTrustRoot` to `SigstoreTrustBundle` to manage both trusted root and signing config

- Add signing config deletion and service URL management capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["signing_config.v0.2.json"] -->|load| B["SigstoreTrustBundle"]
  C["trusted_root.json"] -->|load| B
  B -->|save| D["signing_config file"]
  B -->|save| E["trusted_root file"]
  B -->|manage| F["Service URLs<br/>CA, TSA, Rekor, CTlog"]
  G["delete_signing_config_target"] -->|remove| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Add FileTouch error variant for timestamp operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tuftool/src/error.rs

<ul><li>Add new <code>FileTouch</code> error variant for file timestamp update failures<br> <li> Includes file path and source I/O error information</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/128/files#diff-a3b837e37da806e5e71b047e3bcfba71f19c2aa6f12f4e2a4e4ea3f866b1a58c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rhtas.rs</strong><dd><code>Integrate signing_config.v0.2.json file management throughout</code></dd></summary>
<hr>

tuftool/src/rhtas.rs

<ul><li>Replace <code>SigstoreTrustRoot</code> with <code>SigstoreTrustBundle</code> throughout<br> <li> Add <code>signing_config.v0.2.json</code> file handling alongside <code>trusted_root.json</code><br> <li> Implement file timestamp updates using <code>filetime</code> crate for existing <br>files<br> <li> Add <code>get_latest_signing_config()</code> method to find latest signing config <br>by modification time<br> <li> Update <code>load_trust_bundle()</code> to load both trusted root and signing <br>config files<br> <li> Add signing config file copying and target registration in <br><code>copy_target_files()</code> and <code>set_trust_root_target()</code><br> <li> Implement signing config deletion in <code>remove_target_file()</code> with service <br>URL cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/128/files#diff-428f643623f89ce3436df70f7c3cdcf31841de430080815eb4984c3a0f023b95">+278/-103</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor to SigstoreTrustBundle with signing config support</code></dd></summary>
<hr>

tuftool/src/sigstore_trust/trust/sigstore/mod.rs

<ul><li>Rename <code>SigstoreTrustRoot</code> struct to <code>SigstoreTrustBundle</code> with added <br><code>signing_config</code> field<br> <li> Update <code>from_trusted_root()</code> to <code>from_trust_bundle()</code> accepting optional <br>signing config<br> <li> Add <code>save_signing_config_to_file()</code> method for persisting signing config<br> <li> Implement <code>delete_signing_config_target()</code> to remove service URLs from <br>signing config by URI<br> <li> Update <code>set_target()</code> methods to populate signing config service URLs <br>(ca_urls, tsa_urls, rekor_tlog_urls)<br> <li> Modify <code>from_tough()</code> to fetch and load optional <br><code>signing_config.v0.2.json</code> from repository<br> <li> Update all test fixtures and assertions to use new <code>SigstoreTrustBundle</code> <br>naming</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/128/files#diff-1c4b7cc417414a18ba9ce797e63fae4b9833f83446d9604c587c24a910e7e15a">+202/-35</a></td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add filetime dependency for timestamp operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tuftool/Cargo.toml

- Add `filetime = "0.2"` dependency for file timestamp manipulation


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/128/files#diff-8cd916c64486aab419ca314b581f12dcdc30b1a396ebeab4e6ae9496e4da3c0a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document ctlog-uri parameter in example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tuftool/README.md

<ul><li>Add <code>--ctlog-uri</code> parameter example to delete-ctlog-target command <br>documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/128/files#diff-992f61068424961962c7cb623442041d79679155b94c7da5a740e2f13f3bd6cd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Extend the rhtas command to support signing_config.v0.2.json targets by renaming SigstoreTrustRoot to SigstoreTrustBundle, persisting and deleting signing config, updating file timestamps, and managing associated service URLs.

New Features:
- Support loading, saving, copying, and deleting signing_config.v0.2.json targets in rhtas
- Manage signing_config service URLs (CA, TSA, Rekor, CTlog) within the trust bundle

Enhancements:
- Rename SigstoreTrustRoot to SigstoreTrustBundle and refactor code to handle optional signing config alongside trusted root
- Implement file timestamp updates for trusted_root.json and signing_config.v0.2.json using filetime
- Add get_latest_signing_config method to select the newest signing_config.v0.2.json file
- Update tests and fixtures to use SigstoreTrustBundle instead of SigstoreTrustRoot

Build:
- Add filetime dependency for file timestamp operations

Documentation:
- Document --ctlog-uri parameter in README for delete-ctlog-target command

Tests:
- Update tests to construct and verify SigstoreTrustBundle instead of SigstoreTrustRoot