### PR TITLE
fix: correct permissions on root.json

### DIFF
--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -313,6 +313,11 @@ for file in "${files_to_delete[@]}"; do
     rm -- "$file"
 done
 
+echo "Setting 644 permissions on public repository files ..."
+find "${OUTDIR}" -type f -exec chmod 644 {} +
+
+#Test
+ls -Rla "${OUTDIR}"
 
 echo "Copying the TUF repository to final location ${TUF_REPO_PATH} ..."
 # TODO: fix this based on changes in layout of tuftool output


### PR DESCRIPTION
## Summary by Sourcery

Set correct permissions on root.json in the TUF repository initialization script and add a directory listing for verification

Bug Fixes:
- Ensure root.json is granted 644 file permissions after repository initialization

Enhancements:
- Add recursive directory listing of the output directory for debugging and verification