### PR TITLE
Fix sigstore_trust tests

### DIFF
--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -587,12 +587,12 @@ impl crate::sigstore_trust::trust::TrustRoot for SigstoreTrustRoot {
     fn rekor_keys(&self) -> Result<Vec<&[u8]>> {
         let keys: Vec<_> = Self::tlog_keys(&self.trusted_root.tlogs).collect();
 
-        if keys.len() == 1 {
-            Ok(keys)
-        } else {
+        if keys.is_empty() {
             Err(SigstoreError::TufMetadataError(
-                "Did not find exactly 1 active Rekor key".into(),
+                "Rekor keys not found".into(),
             ))
+        } else {
+            Ok(keys)
         }
     }
 


### PR DESCRIPTION
The Rekor public instance now allows multiple Rekor keys; updated tests accordingly.