### PR TITLE
fix: correct permissions on root.json

### DIFF
--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -313,6 +313,11 @@ for file in "${files_to_delete[@]}"; do
     rm -- "$file"
 done
 
+echo "Setting 644 permissions on public repository files ..."
+find "${OUTDIR}" -type f -exec chmod 644 {} +
+
+#Test
+ls -Rla "${OUTDIR}"
 
 echo "Copying the TUF repository to final location ${TUF_REPO_PATH} ..."
 # TODO: fix this based on changes in layout of tuftool output


### PR DESCRIPTION
## Summary by Sourcery

Set consistent file permissions on generated TUF repository output files before copying them to the final location.

Bug Fixes:
- Ensure all files in the generated TUF repository output directory have 644 permissions to correct previously incorrect permissions.

Enhancements:
- Add a recursive listing of the output directory after permission changes to aid in verifying repository contents and permissions.