### PR TITLE
[SECURESIGN-3399] tuf init: add CLI options for configurable Rekor, Fulcio, CTLog, and TSA URIs instead of hardcoded values

### DIFF
--- a/.github/workflows/trust-root-test.yml
+++ b/.github/workflows/trust-root-test.yml
@@ -35,9 +35,13 @@ jobs:
       - run: |
           ./rhtas/tuf-repo-init.sh --export-keys file:///tmp/exported-keys \
             --fulcio-cert ./rhtas/test/fulcio-cert \
+            --fulcio-uri "https://fulcio.rhtas" \
             --tsa-cert ./rhtas/test/tsa-chain \
+            --tsa-uri "https://tsa.rhtas" \
             --ctlog-key ./rhtas/test/ctfe-pubkey \
+            --fulcio-uri "https://ctlog.rhtas" \
             --rekor-key ./rhtas/test/rekor-pubkey \
+            --fulcio-uri "https://rekor.rhtas" \
             /tmp/testrepo
       - run: curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64" && mv cosign-linux-amd64 ${HOME}/.local/bin/cosign && sudo chmod +x ${HOME}/.local/bin/cosign
       - run: cosign -d initialize --mirror=file:///tmp/testrepo --root=/tmp/testrepo/root.json

--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -18,14 +18,26 @@ Options:
   --fulcio-cert
     Fulcio certificate chain file
 
+  --fulcio-uri
+    Fulcio base URI
+
   --tsa-cert
     TSA certificate chain file
+
+  --tsa-uri
+    TSA base URI
 
   --ctlog-key
     CTLog public key file
 
+  --ctlog-uri
+    CTLog base URI
+
   --rekor-key
     Rekor public key file
+
+  --rekor-uri
+    Rekor base URI
 
   --metadata-expiration
     Tuftool-compatible tetadata expiration time; defaults to 56 weeks
@@ -38,6 +50,10 @@ export FULCIO_CERT=""
 export TSA_CERT=""
 export CTLOG_KEY=""
 export REKOR_KEY=""
+export FULCIO_URI=""
+export TSA_URI=""
+export CTLOG_URI=""
+export REKOR_URI=""
 export METADATA_EXPIRATION="in 52 weeks"
 
 while [[ $# -gt 0 ]]; do
@@ -57,8 +73,18 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    --fulcio-uri)
+      FULCIO_URI="$2"
+      shift
+      shift
+      ;;
     --tsa-cert)
       TSA_CERT="$2"
+      shift
+      shift
+      ;;
+    --tsa-uri)
+      TSA_URI="$2"
       shift
       shift
       ;;
@@ -67,8 +93,18 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    --ctlog-uri)
+      CTLOG_URI="$2"
+      shift
+      shift
+      ;;
     --rekor-key)
       REKOR_KEY="$2"
+      shift
+      shift
+      ;;
+    --rekor-uri)
+      REKOR_URI="$2"
       shift
       shift
       ;;
@@ -169,7 +205,7 @@ if [ -n "${FULCIO_CERT}" ]; then
     --key "${KEYDIR}/targets.pem" \
     --key "${KEYDIR}/timestamp.pem" \
     --set-fulcio-target "${FULCIO_CERT}" \
-    --fulcio-uri "https://fulcio.rhtas" \
+    --fulcio-uri "${FULCIO_URI}" \
     --targets-expires "${METADATA_EXPIRATION}" \
     --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
@@ -190,7 +226,7 @@ if [ -n "${TSA_CERT}" ]; then
     --key "${KEYDIR}/targets.pem" \
     --key "${KEYDIR}/timestamp.pem" \
     --set-tsa-target "${TSA_CERT}" \
-    --tsa-uri "https://tsa.rhtas" \
+    --tsa-uri "${TSA_URI}" \
     --targets-expires "${METADATA_EXPIRATION}" \
     --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
@@ -211,7 +247,7 @@ if [ -n "${CTLOG_KEY}" ]; then
     --key "${KEYDIR}/targets.pem" \
     --key "${KEYDIR}/timestamp.pem" \
     --set-ctlog-target "${CTLOG_KEY}" \
-    --ctlog-uri "https://ctlog.rhtas" \
+    --ctlog-uri "${CTLOG_URI}" \
     --targets-expires "${METADATA_EXPIRATION}" \
     --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \
@@ -231,7 +267,7 @@ if [ -n "${REKOR_KEY}" ]; then
     --key "${KEYDIR}/snapshot.pem" \
     --key "${KEYDIR}/targets.pem" \
     --key "${KEYDIR}/timestamp.pem" \
-    --set-rekor-target "${REKOR_KEY}" \
+    --set-rekor-target "${REKOR_URI}" \
     --rekor-uri "https://rekor.rhtas" \
     --targets-expires "${METADATA_EXPIRATION}" \
     --targets-version 1 \

--- a/rhtas/tuf-repo-init.sh
+++ b/rhtas/tuf-repo-init.sh
@@ -267,8 +267,8 @@ if [ -n "${REKOR_KEY}" ]; then
     --key "${KEYDIR}/snapshot.pem" \
     --key "${KEYDIR}/targets.pem" \
     --key "${KEYDIR}/timestamp.pem" \
-    --set-rekor-target "${REKOR_URI}" \
-    --rekor-uri "https://rekor.rhtas" \
+    --set-rekor-target "${REKOR_KEY}" \
+    --rekor-uri "${REKOR_URI}" \
     --targets-expires "${METADATA_EXPIRATION}" \
     --targets-version 1 \
     --snapshot-expires "${METADATA_EXPIRATION}" \


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add CLI options for configurable Rekor, Fulcio, CTLog, and TSA URIs

- Replace hardcoded service URIs with environment variables

- Enable flexible service endpoint configuration via command-line arguments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Arguments<br/>--fulcio-uri<br/>--tsa-uri<br/>--ctlog-uri<br/>--rekor-uri"] -- "Parse options" --> ENV["Environment Variables<br/>FULCIO_URI<br/>TSA_URI<br/>CTLOG_URI<br/>REKOR_URI"]
  ENV -- "Replace hardcoded" --> TUFTOOL["Tuftool Commands<br/>with dynamic URIs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tuf-repo-init.sh</strong><dd><code>Add configurable service URI CLI options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rhtas/tuf-repo-init.sh

<ul><li>Added four new CLI options: <code>--fulcio-uri</code>, <code>--tsa-uri</code>, <code>--ctlog-uri</code>, and <br><code>--rekor-uri</code> with documentation<br> <li> Introduced four new environment variables to store the URI values<br> <li> Added argument parsing logic for each new CLI option<br> <li> Replaced hardcoded service URIs in tuftool commands with variable <br>references</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/152/files#diff-e6666023365a9b11202da90e45d32cb37edda3efc8386555b61d8d5337db7903">+40/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

