### PR TITLE
chore: swap sha2 usage for openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
  "http 1.2.0",
  "once_cell",
  "percent-encoding",
- "sha2 0.10.8",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -685,15 +685,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -1034,20 +1025,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -1453,7 +1435,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2224,12 +2206,6 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -3288,26 +3264,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4054,7 +4017,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.9.9",
  "sigstore_protobuf_specs",
  "simplelog",
  "snafu",

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -48,7 +48,6 @@ simplelog = "0.12"
 sigstore_protobuf_specs = { version = "0.4", default-features = false, optional = true }
 
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
-sha2 = "0.9"
 pem = "3.0.4"
 prost-types = "0.13.5"
 tempfile = "3"

--- a/tuftool/src/rhtas.rs
+++ b/tuftool/src/rhtas.rs
@@ -15,10 +15,10 @@ use openssl::ec::EcKey;
 use openssl::nid::Nid;
 use openssl::pkey::PKey;
 use openssl::rsa::Rsa;
+use openssl::sha::sha256;
 use prost_types::Timestamp;
 use serde_json::json;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use sigstore_protobuf_specs::dev::sigstore::{
     common::v1::{
         DistinguishedName, LogId, PublicKey, TimeRange, X509Certificate, X509CertificateChain,
@@ -748,10 +748,7 @@ impl RhtasArgs {
 
             let ctlog_raw_bytes = ctlog_raw_bytes_vec[0].clone();
 
-            let mut hasher = Sha256::new();
-            hasher.update(ctlog_raw_bytes.clone());
-            let hash_result = hasher.finalize();
-            let key_id = hash_result.to_vec();
+            let key_id = sha256(&ctlog_raw_bytes).to_vec();
 
             #[allow(clippy::cast_possible_wrap)]
             let current_timestamp = SystemTime::now()
@@ -837,10 +834,7 @@ impl RhtasArgs {
 
             let rekor_raw_bytes = rekor_raw_bytes_vec[0].clone();
 
-            let mut hasher = Sha256::new();
-            hasher.update(rekor_raw_bytes.clone());
-            let hash_result = hasher.finalize();
-            let key_id = hash_result.to_vec();
+            let key_id = sha256(&rekor_raw_bytes).to_vec();
 
             #[allow(clippy::cast_possible_wrap)]
             let current_timestamp = SystemTime::now()

--- a/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
+++ b/tuftool/src/sigstore_trust/trust/sigstore/mod.rs
@@ -21,7 +21,7 @@
 //! These can later be given to [`cosign::ClientBuilder`](crate::cosign::ClientBuilder)
 //! to enable Fulcio and Rekor integrations.
 use futures_util::TryStreamExt;
-use sha2::{Digest, Sha256};
+use openssl::sha::sha256;
 use std::path::Path;
 use tokio_util::bytes::BytesMut;
 
@@ -169,7 +169,7 @@ impl SigstoreTrustBundle {
             )));
         };
 
-        let data = if Sha256::digest(&data)[..] == target.hashes.sha256[..] {
+        let data = if sha256(&data)[..] == target.hashes.sha256[..] {
             data
         } else {
             debug!("{}: out of date", name.raw());


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace sha2 crate with openssl::sha for SHA256 hashing

- Simplify hash computation from multi-step to single function call

- Remove sha2 dependency from Cargo.toml

- Update two hash computation sites in rhtas.rs and one in sigstore mod.rs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sha2["sha2 crate<br/>Digest + Sha256"] -- "replaced by" --> openssl["openssl::sha<br/>sha256 function"]
  multiStep["Multi-step hash<br/>new + update + finalize"] -- "simplified to" --> singleCall["Single function call<br/>sha256()"]
  dep["sha2 dependency<br/>in Cargo.toml"] -- "removed" --> noDep["Dependency removed"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rhtas.rs</strong><dd><code>Replace sha2 with openssl sha256 in key_id calculations</code>&nbsp; &nbsp; </dd></summary>
<hr>

tuftool/src/rhtas.rs

<ul><li>Replaced <code>use sha2::{Digest, Sha256}</code> with <code>use openssl::sha::sha256</code><br> <li> Simplified SHA256 hash computation in ctlog key_id calculation from 4 <br>lines to 1 line<br> <li> Simplified SHA256 hash computation in rekor key_id calculation from 4 <br>lines to 1 line<br> <li> Both changes convert from builder pattern to direct function call</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/153/files#diff-428f643623f89ce3436df70f7c3cdcf31841de430080815eb4984c3a0f023b95">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Replace sha2 with openssl sha256 in metadata validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

tuftool/src/sigstore_trust/trust/sigstore/mod.rs

<ul><li>Replaced <code>use sha2::{Digest, Sha256}</code> with <code>use openssl::sha::sha256</code><br> <li> Simplified SHA256 digest comparison from <code>Sha256::digest(&data)</code> to <br><code>sha256(&data)</code><br> <li> Maintains same functionality with cleaner API</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/153/files#diff-1c4b7cc417414a18ba9ce797e63fae4b9833f83446d9604c587c24a910e7e15a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Remove sha2 dependency from Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tuftool/Cargo.toml

<ul><li>Removed <code>sha2 = "0.9"</code> dependency<br> <li> Reduces external dependencies by leveraging openssl which is already <br>in use</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/tough/pull/153/files#diff-8cd916c64486aab419ca314b581f12dcdc30b1a396ebeab4e6ae9496e4da3c0a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

