### PR TITLE
Rework cli-stack: switch to ubi-micro

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,6 +1,6 @@
 FROM quay.io/securesign/cli-tuftool@sha256:96dd680be18d8d1c3eced452b9f455769fc5b94761dd72bb7cb76b1d3d19b637 AS build-amd64
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774618347@sha256:0f4f6f7868962aa75dddfe4230b664bdf77071e92c43c70c824c58450e37693f AS packager
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS packager
 USER root
 RUN mkdir -p /binaries
 
@@ -9,8 +9,10 @@ COPY --from=build-amd64 /usr/bin/tuftool /tmp/tuftool
 RUN tar -czf /binaries/tuftool_linux_amd64.tar.gz -C /tmp tuftool && \
     rm /tmp/tuftool
 
+RUN chmod -R a+rX /binaries
+
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing tuftool CLI binary for CDN distribution"
 LABEL io.k8s.description="Flat image containing tuftool CLI binary for CDN distribution"
@@ -19,10 +21,9 @@ LABEL io.k8s.display-name="Tuftool CLI stack image for Red Hat Trusted Artifact 
 LABEL io.openshift.tags="tuftool trusted-artifact-signer cli-stack"
 LABEL summary="Provides tuftool CLI binary as tar.gz archive for CDN distribution."
 LABEL com.redhat.component="tuftool-cli-stack"
+LABEL name="rhtas/tuftool-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
-COPY licenses/LICENSE-APACHE /licenses/license.txt
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
+COPY --from=build-amd64 /licenses/ /licenses/
 
 USER 65532:65532


### PR DESCRIPTION
## Summary
- Switch final image from `ubi-minimal` to `ubi-micro:9.8`
- Move `chmod` to packager stage (`chmod -R a+rX` instead of `chown/chmod` in final)
- Update go-toolset to `9.8`
- Copy licenses from component image (`COPY --from=build-amd64 /licenses/`) instead of build context
- Add `name` label

Follows the pattern established in [securesign/trillian#708](https://github.com/securesign/trillian/pull/708).

## Test plan
- [ ] Component image build succeeds on Konflux
- [ ] CLI-stack image build succeeds
- [ ] Enterprise Contract passes
- [ ] Built cli-stack image contains `tuftool_linux_amd64.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)