### PR TITLE
fix: rework cli-stack and enable multi-platform tuf-tool builds

### DIFF
--- a/.tekton/tuf-tool-pull-request.yaml
+++ b/.tekton/tuf-tool-pull-request.yaml
@@ -44,15 +44,25 @@ spec:
     value: "true"
   - name: fips-check
     value: "true"
+  - name: path-context
+    value: .
+  - name: image-version
+    value: "0.0.1"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/securesign/pipelines.git
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build-oci-ta.yaml
     resolver: git
+    params:
+      - name: url
+        value: 'https://github.com/securesign/pipelines.git'
+      - name: revision
+        value: 'main'
+      - name: pathInRepo
+        value: 'pipelines/docker-build-multi-platform-oci-ta.yaml'
   taskRunTemplate:
     serviceAccountName: build-pipeline-tuf-tool-v1-4
   workspaces:

--- a/.tekton/tuf-tool-push.yaml
+++ b/.tekton/tuf-tool-push.yaml
@@ -42,15 +42,25 @@ spec:
     value: "true"
   - name: fips-check
     value: "true"
+  - name: path-context
+    value: .
+  - name: image-version
+    value: "0.0.1"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/securesign/pipelines.git
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build-oci-ta.yaml
     resolver: git
+    params:
+      - name: url
+        value: 'https://github.com/securesign/pipelines.git'
+      - name: revision
+        value: 'main'
+      - name: pathInRepo
+        value: 'pipelines/docker-build-multi-platform-oci-ta.yaml'
   taskRunTemplate:
     serviceAccountName: build-pipeline-tuf-tool-v1-4
   workspaces:

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,12 +1,27 @@
-FROM quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 AS build-amd64
+FROM --platform=linux/amd64   quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS packager
 USER root
 RUN mkdir -p /binaries
 
-# Linux amd64 (tuftool is linux-only, single-platform)
+# Native Linux binaries from each arch variant
 COPY --from=build-amd64 /usr/bin/tuftool /tmp/tuftool
 RUN tar -czf /binaries/tuftool_linux_amd64.tar.gz -C /tmp tuftool && \
+    rm /tmp/tuftool
+
+COPY --from=build-arm64 /usr/bin/tuftool /tmp/tuftool
+RUN tar -czf /binaries/tuftool_linux_arm64.tar.gz -C /tmp tuftool && \
+    rm /tmp/tuftool
+
+COPY --from=build-ppc64le /usr/bin/tuftool /tmp/tuftool
+RUN tar -czf /binaries/tuftool_linux_ppc64le.tar.gz -C /tmp tuftool && \
+    rm /tmp/tuftool
+
+COPY --from=build-s390x /usr/bin/tuftool /tmp/tuftool
+RUN tar -czf /binaries/tuftool_linux_s390x.tar.gz -C /tmp tuftool && \
     rm /tmp/tuftool
 
 RUN chmod -R a+rX /binaries
@@ -14,12 +29,12 @@ RUN chmod -R a+rX /binaries
 # Final minimal image with all binaries
 FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
-LABEL description="Flat image containing tuftool CLI binary for CDN distribution"
-LABEL io.k8s.description="Flat image containing tuftool CLI binary for CDN distribution"
-LABEL io.opencontainers.image.description="Flat image containing tuftool CLI binary for CDN distribution"
+LABEL description="Flat image containing tuftool CLI binaries for all platforms and architectures"
+LABEL io.k8s.description="Flat image containing tuftool CLI binaries for all platforms and architectures"
+LABEL io.opencontainers.image.description="Flat image containing tuftool CLI binaries for all platforms and architectures"
 LABEL io.k8s.display-name="Tuftool CLI stack image for Red Hat Trusted Artifact Signer"
 LABEL io.openshift.tags="tuftool trusted-artifact-signer cli-stack"
-LABEL summary="Provides tuftool CLI binary as tar.gz archive for CDN distribution."
+LABEL summary="Provides tuftool CLI binaries as tar.gz archives for CDN distribution."
 LABEL com.redhat.component="tuftool-cli-stack"
 LABEL name="rhtas/tuftool-cli-stack"
 

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -9,8 +9,10 @@ COPY --from=build-amd64 /usr/bin/tuftool /tmp/tuftool
 RUN tar -czf /binaries/tuftool_linux_amd64.tar.gz -C /tmp tuftool && \
     rm /tmp/tuftool
 
+RUN chmod -R a+rX /binaries
+
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing tuftool CLI binary for CDN distribution"
 LABEL io.k8s.description="Flat image containing tuftool CLI binary for CDN distribution"
@@ -19,10 +21,9 @@ LABEL io.k8s.display-name="Tuftool CLI stack image for Red Hat Trusted Artifact 
 LABEL io.openshift.tags="tuftool trusted-artifact-signer cli-stack"
 LABEL summary="Provides tuftool CLI binary as tar.gz archive for CDN distribution."
 LABEL com.redhat.component="tuftool-cli-stack"
+LABEL name="rhtas/tuftool-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
-COPY licenses/LICENSE-APACHE /licenses/license.txt
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
+COPY --from=build-amd64 /licenses/ /licenses/
 
 USER 65532:65532

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -4,11 +4,13 @@ ENV CGO_ENABLED=1 \
 
 USER root
 
-RUN dnf install -y perl gcc openssl openssl-devel cmake gcc-c++ git curl-minimal unzip cyrus-sasl-devel rust cargo
+RUN dnf install -y perl gcc openssl openssl-devel cmake gcc-c++ git curl-minimal unzip cyrus-sasl-devel rust cargo \
+    $(case "$(uname -m)" in ppc64le|s390x) echo clang ;; esac)
 
 RUN mkdir /tmp/tuftool
 COPY . /tmp/tuftool
-RUN cd /tmp/tuftool && cargo build --release --features fips
+RUN case "$(uname -m)" in s390x) export CFLAGS="-Wno-error=string-compare" ;; esac && \
+    cd /tmp/tuftool && cargo build --release --features fips
 
 FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:8ca59004c1c505bdabadd5202bd3363986f5bf873fcfb36f60561d7362fe52a7 as deploy
 

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,4 +1,4 @@
-packages: [perl, gcc, openssl, openssl-devel, cmake, gcc-c++, git, curl-minimal, unzip, cyrus-sasl-devel, rust, cargo]
+packages: [perl, gcc, openssl, openssl-devel, cmake, gcc-c++, git, curl-minimal, unzip, cyrus-sasl-devel, rust, cargo, clang]
 contentOrigin:
   repofiles: ["./ubi.repo"]
-arches: [x86_64]
+arches: [x86_64, aarch64, ppc64le, s390x]

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -2,50 +2,7881 @@
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
+- arch: aarch64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/annobin-12.98-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 1117109
+    checksum: sha256:9c64856a3b3e04136ab8b62b94fca93b6de87449ce1712c8f26c0af3ab69a9d4
+    name: annobin
+    evr: 12.98-1.el9
+    sourcerpm: annobin-12.98-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cargo-1.88.0-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 7738248
+    checksum: sha256:db106a81f1e6afa16afc7a28d008f42784f6602bca19bd147cb046b5dacc11e5
+    name: cargo
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 360096
+    checksum: sha256:be68ea8774a5aa3b0220043aa21aa93213d4ec0e1cf0c1e9114369ed16ada37e
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 150933
+    checksum: sha256:f0a0bce0ff1d40592b19b3b7bafdc83ba60d192898a185ad4f3813baa9e6d5eb
+    name: clang
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-libs-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 28449643
+    checksum: sha256:43d9a0fd414a30f3250c812b2105943d0267ed08087d8bbeaaa85b0536badcf0
+    name: clang-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-resource-filesystem-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14943
+    checksum: sha256:91112c7c802b64c275db8ec236b462993e11227daddae2fef92fd7fd888741b6
+    name: clang-resource-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.26.5-3.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 7390386
+    checksum: sha256:a44b54f4b495bb869d9facbf6e71444cb1b0bc8e1048a7c5e598c783d688bf5f
+    name: cmake
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.26.5-3.el9_7.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2483069
+    checksum: sha256:6b8afdf96d315c36df391e0f170d5ba845d11704549c4ffa3533aa43922d722e
+    name: cmake-data
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.26.5-3.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18563
+    checksum: sha256:73586d00827daac8ee1929ea3d4153527d355f36fee1daac09955fe967302c1d
+    name: cmake-filesystem
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compiler-rt-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2359240
+    checksum: sha256:615fdd23311c63757c0f583a161ea6b13063cdfcd967d5e8b38cbd410542d75a
+    name: compiler-rt
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 10797009
+    checksum: sha256:eab64632a86902a074d60f7f32d444e1911fcc53b9a8b0de60082eea20bea808
+    name: cpp
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cyrus-sasl-devel-2.1.27-22.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 113419
+    checksum: sha256:b89947958fa47baac6995568502e0da74cb6f101e3e807a1786632c64c632222
+    name: cyrus-sasl-devel
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/d/dwz-0.16-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 136759
+    checksum: sha256:9f019b3e973a6fd234206e48f811f26e7f2790d1c52600b771482a8a051cce01
+    name: dwz
+    evr: 0.16-1.el9
+    sourcerpm: dwz-0.16-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/efi-srpm-macros-6-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21527
+    checksum: sha256:4cf4841f5c7145f3dce72175e09d39b02c7fbb44be552d9d407431a7a81ef9ef
+    name: efi-srpm-macros
+    evr: 6-4.el9
+    sourcerpm: efi-rpm-macros-6-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 30140
+    checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
+    name: fonts-srpm-macros
+    evr: 1:2.0.5-7.el9.1
+    sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 31296441
+    checksum: sha256:6831e31f3fecd845b4058d68c3c3a9cc1fae525f81dda36368ddc550f28bbc5e
+    name: gcc
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12993829
+    checksum: sha256:fd36bff0abdc82a3b4b870a58060e46f6a39b7f15da4d9209bcdd6c1b75cebea
+    name: gcc-c++
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 37106
+    checksum: sha256:a96f113859d6bf4d60cb15f39926493bdd1c81413cc04b742061074cc9c3bfb3
+    name: gcc-plugin-annobin
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-5.el9_7.1.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 7358787
+    checksum: sha256:e25f2dde70ae09977b7edd4684dcfe06520b06a7a23ece48c96891404eea7865
+    name: gcc-toolset-14-binutils
+    evr: 2.41-5.el9_7.1
+    sourcerpm: gcc-toolset-14-binutils-2.41-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-12.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 44238483
+    checksum: sha256:b5c1412d90bd00d86cae444df348cf2de43fba338e0787ba9d777aeda9c3758d
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-12.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13750495
+    checksum: sha256:4e2601e3e4777689db5b0e8783d7aaaccf4909b81d83b41c2619ede62c9ea0a2
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-12.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 3778256
+    checksum: sha256:16365e6867814065ed5c4e87fab1c1a978b827a090acca74b9d1d086b2c31bc6
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 58526
+    checksum: sha256:afe549f07bbaf06f2619d47b18155eaa1f8416dadbff5cbeb99cf17033d7ac25
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9252
+    checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+    sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-2.47.3-1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 51846
+    checksum: sha256:6d80ba0961c5ddebd612a86790023e8086e5c0ed10bc282b088362b98df2c0a9
+    name: git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 5036453
+    checksum: sha256:8f5f3f6fa402ecf4215c36807284dd447c990ff747b1a1150e7d638c37bfbf1e
+    name: git-core
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 3195826
+    checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
+    name: git-core-doc
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-231.el9_7.10.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 574689
+    checksum: sha256:8c65fcccb3edde97d47a2a226cf768476ed4a12a31074a6112925f6569750b20
+    name: glibc-devel
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_7.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 33806
+    checksum: sha256:ea2a392fd650fc6c4928590af98a4b35f705537b0353417599ba97c21b271404
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_7
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2986913
+    checksum: sha256:f768b38bcf574477b6b0fd6a621948447cb8f5aa4e3cf7392cc1a272e794049c
+    name: kernel-headers
+    evr: 5.14.0-611.47.1.el9_7
+    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14098
+    checksum: sha256:54edccc470e78f835a572f809b11413bb62bc5ca765e523eaf17ca23cdde08d3
+    name: kernel-srpm-macros
+    evr: 1.0-14.el9
+    sourcerpm: kernel-srpm-macros-1.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 408716
+    checksum: sha256:247090a8241441529d2c4dc5932ddc1c1075418ba9618d4b8b5e65d1e2aef7b7
+    name: libasan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libdatrie-0.2.13-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 34835
+    checksum: sha256:f804d5f2fd27858d39f1a1c4e76864702b1d24e8d49df77737a547d80d1ee61f
+    name: libdatrie
+    evr: 0.2.13-4.el9
+    sourcerpm: libdatrie-0.2.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 67120
+    checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libomp-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 704770
+    checksum: sha256:1fef7562d0d349fa5c4ab6758154a9c7ab2c362cb9f39203fb0111c36445162f
+    name: libomp
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libomp-devel-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 287573
+    checksum: sha256:6754f79b7df609317970f5422d052200dadbe61c4ffc48dd7ea68428821f444f
+    name: libomp-devel
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2519490
+    checksum: sha256:5b1e4364e2eb59e9443e5014369e2f40f0ab25289ecf8b6243dfb617ea842787
+    name: libstdc++-devel
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libthai-0.1.28-8.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 215793
+    checksum: sha256:211edfbccb7c4cf828a1e078a9b4802f60b783f8e881696efb6cbf018b81cf30
+    name: libthai
+    evr: 0.1.28-8.el9
+    sourcerpm: libthai-0.1.28-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 178723
+    checksum: sha256:03aa0392d5d7a442ee81963eb659b011446e6fcd5904c7b4c2850acdb81e22dc
+    name: libubsan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 150129
+    checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 33051
+    checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-filesystem-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9320
+    checksum: sha256:e92a53ac2ca3dfad1c286f67b86fd80c1ded3e7714a745c7222d8012575a7180
+    name: llvm-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-libs-20.1.8-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 29379083
+    checksum: sha256:ab5ca15a0edd98c358879337c4983f33b433bb7ca39f3252ec69d1523e56065d
+    name: llvm-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 10476
+    checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
+    name: lua-srpm-macros
+    evr: 1-6.el9
+    sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9270
+    checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+    sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 8807
+    checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+    sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.1-7.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 4996906
+    checksum: sha256:d9e2b9611a355580f0010beaee8aa9ca649b5c00225812c30be340b220a7e158
+    name: openssl-devel
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-5.32.1-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 8405
+    checksum: sha256:334764f25cb0e1a7b4efcc8b6d74cbee0e815c9d45148556ec6359762b588037
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 52041
+    checksum: sha256:3d252e247a41978a10faef66931ac5fb2525c7fa708d8caa537d368ef5ba62ce
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+    sourcerpm: perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Archive-Tar-2.38-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 77744
+    checksum: sha256:5cf97230d350543cdf34f379dc04e1383f89591ad76768b5a2738b474cdec404
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+    sourcerpm: perl-Archive-Tar-2.38-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Archive-Zip-1.68-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 118766
+    checksum: sha256:2237a7cdfa30cda2ad475cb6ee5796f1e4cafa07e8760e08bca8d252cd6eb51d
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+    sourcerpm: perl-Archive-Zip-1.68-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Attribute-Handlers-1.01-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 27731
+    checksum: sha256:95ee8b22f5c962b56b95dc3e74280ed1471c17bb2031995d3efd431478e40aac
+    name: perl-Attribute-Handlers
+    evr: 1.01-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21344
+    checksum: sha256:b4557d853be8048aaefde5c4083c43fa34375e224731e93e584e4e3d5db46ac3
+    name: perl-AutoLoader
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-AutoSplit-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21714
+    checksum: sha256:de53b7057da078864d27f4acddf37594d40ee4d5f710d129c40cfb5c6097ceb0
+    name: perl-AutoSplit
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-B-1.80-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 184600
+    checksum: sha256:f7f82b51c586f075eff5f7fb04b96827425974effee364199844dfdc9b3f5a9b
+    name: perl-B
+    evr: 1.80-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Benchmark-1.23-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 27055
+    checksum: sha256:690cc6ca69fd267f025ddc18116d8f10dff6693645ff949820c83ed7776aa454
+    name: perl-Benchmark
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-2.29-5.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 589480
+    checksum: sha256:a46e7bb747f0b5dc26d8eda788b98492576048f5df271d070c35118f8d980b9d
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+    sourcerpm: perl-CPAN-2.29-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 17060
+    checksum: sha256:35687783ded44b01c37af59f66499b42e10df074c36608fc3f84bd4ae082c852
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+    sourcerpm: perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-2.150010-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 210745
+    checksum: sha256:ec35026baabe720d7c880f896f84271f0c408c56d3fea6d7c5d22580ac175690
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+    sourcerpm: perl-CPAN-Meta-2.150010-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 35205
+    checksum: sha256:eca17976f76fd8d31eda995a9ced2d813c1c94b9efafa1a83454fb120be62784
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+    sourcerpm: perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 29542
+    checksum: sha256:b21eb298e56bc6623257cae1434198789e80ab92b818af4e29514a7bbc6f5910
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+    sourcerpm: perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 32039
+    checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
+    name: perl-Carp
+    evr: 1.50-460.el9
+    sourcerpm: perl-Carp-1.50-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22220
+    checksum: sha256:d35ff343bd718fbd8531995a8aedb866c6d37fac6a688fcf9a458017781bf058
+    name: perl-Class-Struct
+    evr: 0.66-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Bzip2-2.28-5.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 74691
+    checksum: sha256:799c6cca489942f0c79b50d749d4b4b7aec7e8272b11ee9f7aa3e90d88e5a01b
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+    sourcerpm: perl-Compress-Bzip2-2.28-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 38610
+    checksum: sha256:3b007ee0457d21868c77c8f003403e17eeabb668aadbc6d25575203f6e9087c8
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 54793
+    checksum: sha256:efe198290b085c6e4eb4cfb426704f1222a4bd1f3cbbecfb636a5fa252ec84b4
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+    sourcerpm: perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 64690
+    checksum: sha256:989520079f36b6281e982ed6de02c8024e5d5696df1fc838eae6b36e74f04805
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Config-Extensions-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12128
+    checksum: sha256:86695c36cd0bd3516cdb72d9f30ddec6aef47eb48432a76b71d15372e86549a6
+    name: perl-Config-Extensions
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Config-Perl-V-0.33-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 24943
+    checksum: sha256:7ec321ecb6f37b6be09ad182cb66fdeee9f12138f75fc48858bde2177c358d1d
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+    sourcerpm: perl-Config-Perl-V-0.33-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DBM_Filter-0.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 32009
+    checksum: sha256:2ea4092322228a400fe8ad6c19302878e46771cbc1a2d623371c49732ad5e018
+    name: perl-DBM_Filter
+    evr: 0.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DB_File-1.855-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 85113
+    checksum: sha256:2cbdfb8cfd2375744b39383311a5e6b590b0773c71eb5bb4f14b3cfcce70eb87
+    name: perl-DB_File
+    evr: 1.855-4.el9
+    sourcerpm: perl-DB_File-1.855-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 58773
+    checksum: sha256:0ac738aff66419ff8853d2e2b8d2fe231b90de129060ecc0390bca9c6c680e0d
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+    sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-OptList-0.110-17.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 30694
+    checksum: sha256:1455a3e90116f504008f8d27db57acb65c3389440dc6e2d605f54bf40b009a10
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+    sourcerpm: perl-Data-OptList-0.110-17.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-Section-0.200007-14.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 28030
+    checksum: sha256:9fb57b4fbcfea93de114505082261abd97f576cf78e1a205c255d69d8eb6babf
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+    sourcerpm: perl-Data-Section-0.200007-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-PPPort-3.62-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 217292
+    checksum: sha256:b9391222f4cef0811b4e99c73b03c22b19fdb99ea4959bbd412fdb2f6fd627d0
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+    sourcerpm: perl-Devel-PPPort-3.62-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-Peek-1.28-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 31959
+    checksum: sha256:93e9bb94fe8ce391149ce2f0fb6fb90851d6f16b9c2c0dd1f63c47cbb129b9d5
+    name: perl-Devel-Peek
+    evr: 1.28-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-SelfStubber-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14231
+    checksum: sha256:703faaef6ca5a65ed4c3cbdb256da9612eed842bd77620a2d527ca8d0fa8a7d2
+    name: perl-Devel-SelfStubber
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-Size-0.83-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 34781
+    checksum: sha256:736d3ec0babbdea08633d4bd4bd9121e906e916eb5ac5527d093814a9925c57d
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+    sourcerpm: perl-Devel-Size-0.83-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 29409
+    checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
+    name: perl-Digest
+    evr: 1.19-4.el9
+    sourcerpm: perl-Digest-1.19-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 40515
+    checksum: sha256:6eeb8e68cfbd7cca24d6132be8b947de99ab26cdb79d6021e9e6efeb36b67e0b
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+    sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-SHA-6.02-461.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 67396
+    checksum: sha256:ed614bb03e34d4bf5b87de4fc9051911bf2e6080921cdaece18e3f826e6b1319
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+    sourcerpm: perl-Digest-SHA-6.02-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-SHA1-2.13-34.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 57513
+    checksum: sha256:59ecc753d4548f1530d4951475df7f4c703c12519e9488988d1e35b618e79db4
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+    sourcerpm: perl-Digest-SHA1-2.13-34.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DirHandle-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12337
+    checksum: sha256:2c79a7d1c783c4eb4305e7b15c885c7afc5e2612ab4b1245f4f9ef8dcff4804f
+    name: perl-DirHandle
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Dumpvalue-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18343
+    checksum: sha256:7659f1dab24e96da4be5624f90a3ac04b383071a96a32e185b196bc527377e1c
+    name: perl-Dumpvalue
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25913
+    checksum: sha256:cddb0b2e16a10b80b6b3ffd6409b210aeba404acc589a958f280cac24d12403f
+    name: perl-DynaLoader
+    evr: 1.47-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 1825541
+    checksum: sha256:72c92a12c67d05f9aa7f5670ccb1b743612d8fa946775feada28e199a31db0a9
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-Locale-1.05-21.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21500
+    checksum: sha256:58afacf30f4a476f4ba6646a6419122d2a729bd59880611b631527502dcdc269
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+    sourcerpm: perl-Encode-Locale-1.05-21.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-devel-3.08-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 45137
+    checksum: sha256:bc3e56fb27a8e5947e2fc4bb705c06b10f1dcab42f411cd300e2137ad8f07b35
+    name: perl-Encode-devel
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-English-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13497
+    checksum: sha256:04a48f25493933a3ae04eac446efefa1d4c092e323db1561e7653e4f570987da
+    name: perl-English
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Env-1.04-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22160
+    checksum: sha256:92fb2287084a3c88a6b2d2bd300d1279251cec59156c1a9a3e0fa8fda6c546b2
+    name: perl-Env
+    evr: 1.04-460.el9
+    sourcerpm: perl-Env-1.04-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Errno-1.30-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14826
+    checksum: sha256:be31dbcae3e58ea4094719bf3882aa3c35599a152341cb48d2aec1aba787d877
+    name: perl-Errno
+    evr: 1.30-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 47552
+    checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
+    name: perl-Error
+    evr: 1:0.17029-7.el9
+    sourcerpm: perl-Error-0.17029-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 34509
+    checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
+    name: perl-Exporter
+    evr: 5.74-461.el9
+    sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 54624
+    checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+    sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16489
+    checksum: sha256:642338ff95d94e2c6e4b7de47cda7b772d1fbc204b2869925bd0326fcc4b0e26
+    name: perl-ExtUtils-Command
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Constant-0.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 47285
+    checksum: sha256:f10abe9f8d9f26c2ef2f278baf37a98e7a654cf192521d72bb797a3ef2131698
+    name: perl-ExtUtils-Constant
+    evr: 0.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Embed-1.35-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 17684
+    checksum: sha256:10fa80d9248c159ad12cce5222d3d1b82953ddfc7c4123ca0b14b5d5340e1421
+    name: perl-ExtUtils-Embed
+    evr: 1.35-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Install-2.20-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 48441
+    checksum: sha256:2533a1d97d45dc79c07cc51409c34f188c042757a2811b04dc16892ae2c7443e
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+    sourcerpm: perl-ExtUtils-Install-2.20-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-MM-Utils-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14176
+    checksum: sha256:51d7199c10886580e6cbff82546a34f26b2d5b894dcc338e28b1b55938f50ae3
+    name: perl-ExtUtils-MM-Utils
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 311769
+    checksum: sha256:2286e5004cb6436b7ac8dd436c91b4e1d36c18b9385d07a24fc167c930c9dee8
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 37829
+    checksum: sha256:f7cf7fd259fb8a6c27537dc98e1ed4923b26c2d8d8fd6b789e166ac104cac5bc
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+    sourcerpm: perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Miniperl-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15171
+    checksum: sha256:6b00fb367aea4654a14495802d46daa87d2e51ee203a8b0e207edae507773edc
+    name: perl-ExtUtils-Miniperl
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 194711
+    checksum: sha256:bb7e4bcfe24371bbe202a9fa704360a7bbc5d9f4103ec36e6e571da6eb76a186
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+    sourcerpm: perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Fcntl-1.13-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 20270
+    checksum: sha256:2dcec56d48812e21c75b6e23a5ee613e7b68aa0d6136e5f9f37bc841592bae97
+    name: perl-Fcntl
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Basename-2.85-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 17211
+    checksum: sha256:e39dcc13a24d3b5a7ba11288e63b22a055a8e1061743b8a409858d98ebd794e4
+    name: perl-File-Basename
+    evr: 2.85-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Compare-1.100.600-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13166
+    checksum: sha256:0dd800746b848a84fce73dcef035c4241e6aa90262c821a0ad295a7756ca1a4c
+    name: perl-File-Compare
+    evr: 1.100.600-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Copy-2.34-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 20143
+    checksum: sha256:165816db79e88e63c96bdafaf0c3bfee95b6feedb78e40da3a6dcc196a15a186
+    name: perl-File-Copy
+    evr: 2.34-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-DosGlob-1.12-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 19467
+    checksum: sha256:e5d1f8546e60d9b815667a44d9140bb3270cbf5d46d8fc9e8d3ca148e9af98db
+    name: perl-File-DosGlob
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Fetch-1.00-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 33372
+    checksum: sha256:8c46735b0f703cd53fbaf915423b63baf98701d81406b30b84e42e53a0efbb6e
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+    sourcerpm: perl-File-Fetch-1.00-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Find-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25551
+    checksum: sha256:002ec6d107fff6949f1a88965fb31b0a4efe6ce663395ab47e0cb939e3920c08
+    name: perl-File-Find
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-HomeDir-1.006-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 65857
+    checksum: sha256:68f539b86abb7ab910286188ad3742f4338330f3246f6da07cb4ca5c83d8e80f
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+    sourcerpm: perl-File-HomeDir-1.006-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 38466
+    checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
+    name: perl-File-Path
+    evr: 2.18-4.el9
+    sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 64150
+    checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+    sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Which-1.23-10.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 24163
+    checksum: sha256:80a41f9f823312dca2c9fed97f6568a88957572277b75920fb76f20a60902e7f
+    name: perl-File-Which
+    evr: 1.23-10.el9
+    sourcerpm: perl-File-Which-1.23-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-stat-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 17117
+    checksum: sha256:b235134c1961e9b57f86bddc02e874607c17c155d2aa5ad78cc3ed9c8fd9c95b
+    name: perl-File-stat
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FileCache-1.10-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14640
+    checksum: sha256:0b0ab9a79395bb7a926ec674b66f42845580903f514c511da156ffd497205f42
+    name: perl-FileCache
+    evr: 1.10-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FileHandle-2.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15452
+    checksum: sha256:c2139abdb9b3335f592aa2835ef6d6fcde1e89232eb3d3c5a15f7cc1d0829f8d
+    name: perl-FileHandle
+    evr: 2.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Filter-1.60-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 97366
+    checksum: sha256:723bcc532676617221a0720fb91feeea644bde3b413a38c16e287cc36ace166f
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+    sourcerpm: perl-Filter-1.60-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Filter-Simple-0.96-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 29899
+    checksum: sha256:080a1c4c16acddca179c0e2ab8120fe01e374bb86d0a950923a610e50fabfc00
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+    sourcerpm: perl-Filter-Simple-0.96-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FindBin-1.51-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13872
+    checksum: sha256:44f9c97a57dafae68f8183d1ca2682a8308b68f1a399ab333a3dd52836bb6b17
+    name: perl-FindBin
+    evr: 1.51-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-GDBM_File-1.18-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22062
+    checksum: sha256:790bdbbd82ee60e4da98866d6c584c7ec3f730c0dd6eb261e7fcd429f1435b32
+    name: perl-GDBM_File
+    evr: 1.18-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 65144
+    checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+    sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15551
+    checksum: sha256:49bd8381823d680d17c37f3bebfd97dd92bfbf59e8019f15c7606f41dca02a7d
+    name: perl-Getopt-Std
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 38720
+    checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
+    name: perl-Git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 58720
+    checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+    sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Hash-Util-0.23-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 34401
+    checksum: sha256:2654a95b9ab0669d739ebbf6ef1c7469dd6a1947af648e8c8d8c29aab92608e4
+    name: perl-Hash-Util
+    evr: 0.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Hash-Util-FieldHash-1.20-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 38300
+    checksum: sha256:1f797de78b5d8b994210126debb29a3aed4264f7fbbf763733772b988f751a3e
+    name: perl-Hash-Util-FieldHash
+    evr: 1.20-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-Collate-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14091
+    checksum: sha256:82a82eb1e6765c7b4ec245a624f34e73d6a7b2c9c15a90007bcbb64113332793
+    name: perl-I18N-Collate
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-LangTags-0.44-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 55212
+    checksum: sha256:f0849fe10730cf503bebfbd82e3dfb39d64ef87667ee9a1a073df8fd231878d6
+    name: perl-I18N-LangTags
+    evr: 0.44-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-Langinfo-0.19-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22366
+    checksum: sha256:9a2b8266d39fb9307edd88e26335fe39cd5526c7ae2c24ee291e539dafccceb0
+    name: perl-I18N-Langinfo
+    evr: 0.19-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-1.43-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 90373
+    checksum: sha256:eb00f890b53bb5335be0d35994869e8855ad62668ef5199688ab951ffd8c76b6
+    name: perl-IO
+    evr: 1.43-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Compress-2.102-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 280708
+    checksum: sha256:ce8f2004395442fe663cb9efc56f9af2102c75d746f2ce393e40af8a26ac6871
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+    sourcerpm: perl-IO-Compress-2.102-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 84153
+    checksum: sha256:bda4c005c09e886ce2273a3f418f0cd92521ed0b8fdcdaca7b9fc0026f2a6c7b
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+    sourcerpm: perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 46457
+    checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+    sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Zlib-1.11-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21809
+    checksum: sha256:87d7b757a570fb53d72b2dd29558c2b4a8ff33196a80ad10f76999325acaec07
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+    sourcerpm: perl-IO-Zlib-1.11-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-Cmd-1.04-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 42803
+    checksum: sha256:353b04bed7229ce354a4d63ba213c4e18fe739c4732061957946b84853d5b3ce
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+    sourcerpm: perl-IPC-Cmd-1.04-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22968
+    checksum: sha256:7ea36dcf28da3fc7250eb041ba19f99c87543c0870f5da67da614f5ca8d18b92
+    name: perl-IPC-Open3
+    evr: 1.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-SysV-2.09-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 48827
+    checksum: sha256:4b33d8a7c5ae11c075ca84de9aa2ba5c74e5a021f9e69ddee1093e6b1970815c
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+    sourcerpm: perl-IPC-SysV-2.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-System-Simple-1.30-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 44255
+    checksum: sha256:35792b1aa241cb17b881b1e44940bc295329a575a2a2d183757ef1d757062465
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+    sourcerpm: perl-IPC-System-Simple-1.30-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Importer-0.026-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 42526
+    checksum: sha256:1afb9008ad841ba4fc207af8ec814d06bd78e958cd2b03089c7b82c71a311060
+    name: perl-Importer
+    evr: 0.026-4.el9
+    sourcerpm: perl-Importer-0.026-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-JSON-PP-4.06-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 70596
+    checksum: sha256:17f547d40976904eb59449f0cdec890e34632a28a083fc46157ac1c67e9e3494
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+    sourcerpm: perl-JSON-PP-4.06-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Locale-Maketext-1.29-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 101003
+    checksum: sha256:97cfef112a414049f85495cbec570b8c63d7260410f72cb2e1480a67fc7e9e68
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+    sourcerpm: perl-Locale-Maketext-1.29-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Locale-Maketext-Simple-0.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 17604
+    checksum: sha256:206fca125c5520e6e0723c6f8ee4c9b56d5bec95c7d71e4b54fdad36ddf20980
+    name: perl-Locale-Maketext-Simple
+    evr: 1:0.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 35080
+    checksum: sha256:8fd71ba1ada7ab6b0b83400716671139a7adbf01d9bfed881398497170ccb308
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+    sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MIME-Charset-1.012.2-15.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 54488
+    checksum: sha256:cf481c2178bc2a55c5b455749f38f4f96ee71f32dcf458c34d4f1bbcb996feca
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+    sourcerpm: perl-MIME-Charset-1.012.2-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MRO-Compat-0.13-15.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22804
+    checksum: sha256:7921d8fd6d4dacdfb4a286fe4355516f20d660681abb49af9983f7527429e351
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+    sourcerpm: perl-MRO-Compat-0.13-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 198900
+    checksum: sha256:b90555cc3da95e314e931de2348d7c89da7c16023fb9399cdfbbcf9f1aeade7d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+    sourcerpm: perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 32494
+    checksum: sha256:20b48aa36f522ccc9047fa01cb665ef20ae6a48f1b3a289e37481c159655e5b6
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+    sourcerpm: perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigRat-0.2614-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 42414
+    checksum: sha256:c31888896769451095c352ea97a1c88e2bbbc27d5bdc1e018dc8bae680967fb0
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+    sourcerpm: perl-Math-BigRat-0.2614-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-Complex-1.59-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 47421
+    checksum: sha256:754d5798c9a2bb21714671fdf0236e5937511bf59c473fdef8117c512410e8b5
+    name: perl-Math-Complex
+    evr: 1.59-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Memoize-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 57798
+    checksum: sha256:f668ee6ce94bab8e3a926587a1ab2f4ed3a4490d911c2e7fc1b2fe074a6cfdcc
+    name: perl-Memoize
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Build-0.42.31-9.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 274094
+    checksum: sha256:9e33e1a46048d262ebe06f98c6c7b1579cdf92db57b0bb4228d13883c232d82c
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+    sourcerpm: perl-Module-Build-0.42.31-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-CoreList-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 92615
+    checksum: sha256:fe85ea513ac696ce4d4bd5565259d89edde346d5a049d0eed153eac988ef73fd
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-CoreList-tools-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18135
+    checksum: sha256:2df9f5a5329e94c19bab88ba530149a86438756c7404787b03745f711adf3368
+    name: perl-Module-CoreList-tools
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Load-0.36-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 20052
+    checksum: sha256:ada066ac44fd73ec87ea376a6d6715cf77b086354217fdc7a197c909da3bb099
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+    sourcerpm: perl-Module-Load-0.36-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25464
+    checksum: sha256:58a5364d77607678e4e628f5bdd3d33641e2f6083c2985c1bc5045401ae65a60
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+    sourcerpm: perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Loaded-0.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13245
+    checksum: sha256:5873834f46d56066cab07a5386daccf8b4db7ccf23344967dcdc31a893907778
+    name: perl-Module-Loaded
+    evr: 1:0.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Metadata-1.000037-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 39221
+    checksum: sha256:f053b34c911e5f3daf16c0ffc5ff752f47a0d016e1cc1ac51d4425fbe2a1ac15
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+    sourcerpm: perl-Module-Metadata-1.000037-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Signature-0.88-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 89282
+    checksum: sha256:1a173631124cdb77ffa2cb11ceb8de813f6e4222e5bf9ae657947211480858e6
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+    sourcerpm: perl-Module-Signature-0.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14781
+    checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+    sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21832
+    checksum: sha256:6a03c4415b13ab8b960e9b1c5440058d006f159c113abdca1c7c4cbec4e2cd58
+    name: perl-NDBM_File
+    evr: 1.15-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-NEXT-0.67-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21043
+    checksum: sha256:30c7f7f97f369fb9264c0c01f7f12fe1791c99e920aebdf149d71f945f814ec6
+    name: perl-NEXT
+    evr: 0.67-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25539
+    checksum: sha256:2bb0dceeec12a995caf29411056c2108a6f09b6bbe6d31090114fa4cbec53454
+    name: perl-Net
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-Ping-2.74-5.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 53027
+    checksum: sha256:fb74fb2651f62421538bb05992af5251887013a72c4412f5c2421992204c03bc
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+    sourcerpm: perl-Net-Ping-2.74-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 424450
+    checksum: sha256:d2781d36ecbfb5fbbb3d73a589dfef6fcaa694facee347d0a66d70b07ebe0ed8
+    name: perl-Net-SSLeay
+    evr: 1.94-3.el9
+    sourcerpm: perl-Net-SSLeay-1.94-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ODBM_File-1.16-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21824
+    checksum: sha256:6c8c69acef6ae0a6f7ce1853061798cac6107ec6a459e102e6e0e23e09b51b4d
+    name: perl-ODBM_File
+    evr: 1.16-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Object-HashBase-0.009-7.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 28938
+    checksum: sha256:2144d4c29ea4acfc0d872bf09cb4d9dce14a64e60a45633f1a31ed3a2b125ee8
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+    sourcerpm: perl-Object-HashBase-0.009-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Opcode-1.48-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 36640
+    checksum: sha256:ec91248e4ff688b0850651d3dc6dce6c7716fe00adc7ab71692703cbc425ca3b
+    name: perl-Opcode
+    evr: 1.48-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-POSIX-1.94-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 98493
+    checksum: sha256:1afecd9468a279bcf9c4e2d7d37f09cc3779f7b869a26ba3d0dcef78f7b9c0af
+    name: perl-POSIX
+    evr: 1.94-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Package-Generator-1.106-23.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 26822
+    checksum: sha256:2c9b4699185c30d1da293add16911555e93b7532d77e59aa07e2c9c8d8eafcf3
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+    sourcerpm: perl-Package-Generator-1.106-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Params-Check-0.38-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 24764
+    checksum: sha256:a6cf1009e3f1dfe50e00421b11d43c413e7e4ee8c6931195256a3cb40e1baf7b
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+    sourcerpm: perl-Params-Check-0.38-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Params-Util-1.102-5.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 38447
+    checksum: sha256:e8219eff046c4d85aeaf4581037b8e3aea3db9fd56bf648d84588fbd5b27123a
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+    sourcerpm: perl-Params-Util-1.102-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 94325
+    checksum: sha256:5cd800158be7a9ddaf8e9c5d193d10992e01a35c4f438ff072852d194e3a5311
+    name: perl-PathTools
+    evr: 3.78-461.el9
+    sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Perl-OSType-1.010-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 26284
+    checksum: sha256:64f37a98e22fce4ee9520da6db13ab601e21e34ac9d3ae7f85fc7a63761c492b
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+    sourcerpm: perl-Perl-OSType-1.010-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25566
+    checksum: sha256:31d1284cda8a84f78574ae2380474412788de756613bcb11a85d68c94af9ba0b
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+    sourcerpm: perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Checker-1.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 35171
+    checksum: sha256:7410aed54bb1c0a18b7b0ec33b6067475383b557defdd295b48b3277229d31a1
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+    sourcerpm: perl-Pod-Checker-1.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 22564
+    checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+    sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Functions-1.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13531
+    checksum: sha256:8afc31372f05f71a11054c7d7318301d3d65547abc7eac3ed56d428843edae0c
+    name: perl-Pod-Functions
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Html-1.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 26780
+    checksum: sha256:f692dea024e6ced870a5f792db9e76e06d810dfce9846bb59e5b4442b28820e6
+    name: perl-Pod-Html
+    evr: 1.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 93727
+    checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+    sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 234403
+    checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+    sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 44477
+    checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+    sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Safe-2.41-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25188
+    checksum: sha256:ca9095157a26e3ee611c9b9ef6c075086a2381571fccc1a45ade5f8f88c5a78e
+    name: perl-Safe
+    evr: 2.41-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 76001
+    checksum: sha256:5e3592356c1610311f5bf8be4cbc9e35ad04d6b3ba089d70b700d8b70f534635
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Search-Dict-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12900
+    checksum: sha256:f57497238bbc4edb96b24f88084e5d21f4e3aebab5d33a6db5e79a2ea53ce70d
+    name: perl-Search-Dict
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 11553
+    checksum: sha256:8ec404df551d6cc4750efa34b9897d2288d07a26d49cd3d3d2315584976932b0
+    name: perl-SelectSaver
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-SelfLoader-1.26-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 21729
+    checksum: sha256:18a1b56a5a1097748cc998cb5305f5d77e253a05bae807b418694805fc413c8e
+    name: perl-SelfLoader
+    evr: 1.26-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 59426
+    checksum: sha256:f69c6cd2c48606efa7477ef73ef2cb03c07aa02d535f03824dbe966f6235cc88
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+    sourcerpm: perl-Socket-2.031-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Software-License-0.103014-12.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 147494
+    checksum: sha256:c225b78b513fc8b90a0b2b773fadcf65dd2defe2a147fca67c52971d2750f437
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+    sourcerpm: perl-Software-License-0.103014-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 98115
+    checksum: sha256:61a7bc7d2a2e3b0c42289927a1ecc7b9f672ce3281be58a59b3b2875e4203457
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+    sourcerpm: perl-Storable-3.21-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sub-Exporter-0.987-27.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 78523
+    checksum: sha256:4e2535cd4d456f91f346e6d690c9a22c4b2a01318f9a5b5f761e1170d815bed1
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+    sourcerpm: perl-Sub-Exporter-0.987-27.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sub-Install-0.928-28.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25233
+    checksum: sha256:4ce03d243d1331188c5a2b0e4103dad6b930ba36362cd353f0f3cd0998784e82
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+    sourcerpm: perl-Sub-Install-0.928-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Symbol-1.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14061
+    checksum: sha256:aa9942be4c837c024c6a0a376b13f9563e16ee8b66631ad6c5ff35cd0124728d
+    name: perl-Symbol
+    evr: 1.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sys-Hostname-1.23-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16947
+    checksum: sha256:92c9db4a5b34f6f57c858cf6265e62a7102b8fa8f3612a85a2f4226f349e775a
+    name: perl-Sys-Hostname
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sys-Syslog-0.36-461.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 52646
+    checksum: sha256:ec4ca7f72dff339eed3d7878ec86af177cf6d21402a002558142173eabf3c9ec
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+    sourcerpm: perl-Sys-Syslog-0.36-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 52228
+    checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+    sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25043
+    checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+    sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Complete-1.403-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12886
+    checksum: sha256:fe5f8688a2a28327a35be1caa35a9d7b8718531120ddfdb10da6f80d6b577059
+    name: perl-Term-Complete
+    evr: 1.403-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-ReadLine-1.17-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 19061
+    checksum: sha256:506c2fb3304f36ce437696dea9fb8772424a08345c765b25ac7278e429df1dcf
+    name: perl-Term-ReadLine
+    evr: 1.17-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Size-Any-0.002-35.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16309
+    checksum: sha256:e83c29bb60e3fdac1c7aa5d3cde8a6b237812a14fe8f711bf6e127ed96d929a4
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+    sourcerpm: perl-Term-Size-Any-0.002-35.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Size-Perl-0.031-12.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25142
+    checksum: sha256:0acd3a4bd0f98b24701f88a6853ba39f11c490fa816e44e7209690d23960cfbf
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+    sourcerpm: perl-Term-Size-Perl-0.031-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Table-0.015-8.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 40852
+    checksum: sha256:3e0c26e1b0e31d17cc133829ad8d6e22c86e532e9b6a3c26f48b7ec447bdfbb4
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+    sourcerpm: perl-Term-Table-0.015-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 40577
+    checksum: sha256:bfe0d10d4c1028a7929ca213bfd3871f059ea0daeec4c48f3e85d54d77a5a2fc
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+    sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 28830
+    checksum: sha256:879484e27419a62c5eb942327570be90f246334000d9e3af1e052155b6e08661
+    name: perl-Test
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-Harness-3.42-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 306138
+    checksum: sha256:7980ae9e28aed0aadef4f169e8479812a2a6bacf05ee53001f63d021b065fe40
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+    sourcerpm: perl-Test-Harness-3.42-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-Simple-1.302183-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 645034
+    checksum: sha256:04ae40e07d57934e5dc3946fa638023ee76305dac04bed7813ed338b0a4c2ef2
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+    sourcerpm: perl-Test-Simple-1.302183-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Abbrev-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12026
+    checksum: sha256:7671d9b159be320b1725a11b9ba5a9d15b809ec22ba13e0ae5cacf5ed09fdec1
+    name: perl-Text-Abbrev
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Balanced-2.04-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 51500
+    checksum: sha256:67ff60f60b6dc900e840ed51ff3b1cabef9e43aa48cba81ad97ae9423bdca5af
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+    sourcerpm: perl-Text-Balanced-2.04-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Diff-1.45-13.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 45523
+    checksum: sha256:5141fc840dc2989b44df904df2cadfdc3b6b9d38a7e4dba2c2db3c14e3dbc060
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+    sourcerpm: perl-Text-Diff-1.45-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Glob-0.11-15.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15921
+    checksum: sha256:079d5eb4a606a131eaeecfcbd7f7d39a21c9c49b97bd6b84f7d08986dd11dc59
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+    sourcerpm: perl-Text-Glob-0.11-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18680
+    checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+    sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25935
+    checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+    sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Template-1.59-5.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 64485
+    checksum: sha256:3c7350777e9d26fe4c02d52e8c4d4e0643ee32f8abfb9e22fc28f5325702924e
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+    sourcerpm: perl-Text-Template-1.59-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-3.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18018
+    checksum: sha256:0caef6e47205d0035b3f692010e9f7dcd710e7832da77a2a5abbe930440f7e48
+    name: perl-Thread
+    evr: 3.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-Queue-3.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 24804
+    checksum: sha256:88d838d681ad683970eb8566e8936faabffc3495dd1b555f083a1cd00538291a
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+    sourcerpm: perl-Thread-Queue-3.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-Semaphore-2.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15604
+    checksum: sha256:136b09ee2841a1b6655f0a29759fe353b7f4b12ea3e559bafd39d4c508644925
+    name: perl-Thread-Semaphore
+    evr: 2.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-4.6-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 31837
+    checksum: sha256:7144466ebb0d8dc2b7af2deac1dddd8caa23b35bcc0d42829c9b242b18f39d6c
+    name: perl-Tie
+    evr: 4.6-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-File-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 43818
+    checksum: sha256:f99032921dc45c8a77f91909b5329a95fc4bade37815e2e866c70bf6f39a7c82
+    name: perl-Tie-File
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-Memoize-1.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14038
+    checksum: sha256:1f3395cf1a045adfabf0e9b82bc4676f0dd1d76a985afedb3e069e6e9128c677
+    name: perl-Tie-Memoize
+    evr: 1.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-RefHash-1.40-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 26260
+    checksum: sha256:5519a86c145d83a1633a127f7b0b6a371e6b2b8a647dabff45c2754388504a44
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+    sourcerpm: perl-Tie-RefHash-1.40-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18651
+    checksum: sha256:e23d1ba4c2e8d4283e757a7af563a24038b5829ed55c9bc90b4bae8c498ec5d7
+    name: perl-Time
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-HiRes-1.9764-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 62449
+    checksum: sha256:87390bc4f89cd00517fbed954004f851334dc081e9cbf679ed8f9cc75f02c531
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+    sourcerpm: perl-Time-HiRes-1.9764-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 37469
+    checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+    sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-Piece-1.3401-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 40806
+    checksum: sha256:f2efe674294a89db9aabe8add3d6b55ec0b17771707f7e21e839a8c085540fa5
+    name: perl-Time-Piece
+    evr: 1.3401-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 128279
+    checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
+    name: perl-URI
+    evr: 5.09-3.el9
+    sourcerpm: perl-URI-5.09-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-Collate-1.29-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 761716
+    checksum: sha256:c21e4ffbdb9e9bd3b3c297b059bedd421ab458a3ec7970b93e5e30914006f2d9
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+    sourcerpm: perl-Unicode-Collate-1.29-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 132417
+    checksum: sha256:7b0786e7b16f27ee07070c31e6ab17fd4474c327e5d94185c34849f1a57d432d
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+    sourcerpm: perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-Normalize-1.27-461.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 92474
+    checksum: sha256:7ca97e263d79d5a0e5f2093c54bcb73399532562e5bd15b30f1762cf8b1c3359
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+    sourcerpm: perl-Unicode-Normalize-1.27-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-UCD-0.75-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 79927
+    checksum: sha256:208f347f513df7c59ab77d90b54d3c9ed4cf67e733887783354a2c6ebeaf6409
+    name: perl-Unicode-UCD
+    evr: 0.75-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-User-pwent-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 20597
+    checksum: sha256:f131ac194a35b3b17f5ff6961e9bb9eb031fd5c7d0055e05a438c11b53931263
+    name: perl-User-pwent
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-autodie-2.34-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 103286
+    checksum: sha256:8c4a7c8fd5074801946cce0b0b2f47337036e7f64e4cb9c833d9cf1de1f14edc
+    name: perl-autodie
+    evr: 2.34-4.el9
+    sourcerpm: perl-autodie-2.34-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-autouse-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13668
+    checksum: sha256:c2502f538edef3d9b9ad20cdc8c0f8e971ac651df6c07f8555aa315b602c085a
+    name: perl-autouse
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-base-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16220
+    checksum: sha256:0be44f055107893b011ed0e88f39ff202ba451db8a94351ad4472d350c780d0d
+    name: perl-base
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-bignum-0.51-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 48635
+    checksum: sha256:a25963adbb78901e2581a041252bfc96f55e534403e4af513d8728c62f0b4800
+    name: perl-bignum
+    evr: 0.51-460.el9
+    sourcerpm: perl-bignum-0.51-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-blib-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12267
+    checksum: sha256:50560de5f252c718728c45cb7af3742252581416e0acb9cfacd686dad58c0028
+    name: perl-blib
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 25865
+    checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
+    name: perl-constant
+    evr: 1.33-461.el9
+    sourcerpm: perl-constant-1.33-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-debugger-1.56-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 136515
+    checksum: sha256:0b96f38c73512a61ce84171578bc9fcc5a957ff1fb267749f3af18bc7d1ce1bd
+    name: perl-debugger
+    evr: 1.56-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-deprecate-0.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14490
+    checksum: sha256:033aae2f09a7f78be08ae590f95cbce8025e5d5574cdab2bc77b554ad6e81575
+    name: perl-deprecate
+    evr: 0.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-devel-5.32.1-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 692078
+    checksum: sha256:5dba8e84824236c205e420fc5aed86f3177c8e78937b08eed6b4bb7c06feaa8e
+    name: perl-devel
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-diagnostics-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 215534
+    checksum: sha256:19c65175b0df9d6142bf08d6566b8f10c331735c8b95690adbc300b670a692c4
+    name: perl-diagnostics
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-doc-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 4798228
+    checksum: sha256:d9eb81a356338df906db80c853c092a1fb0de745726e82db44fb343d267b4091
+    name: perl-doc
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-encoding-3.00-462.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 65958
+    checksum: sha256:43b1c0c7e7f6029f5610355e2fdea3fb8c6fa1cc956331f53a8b7d4bb8bb65e4
+    name: perl-encoding
+    evr: 4:3.00-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-encoding-warnings-0.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16539
+    checksum: sha256:897e244bb8f8800a3ed23d669df746b0bb3672cd6929b06e04e5da63b04a5aa3
+    name: perl-encoding-warnings
+    evr: 0.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-experimental-0.022-6.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 24376
+    checksum: sha256:ae48d202863aba2573c70d803a9931de4e3c4b0d3e4f2df561bcc1bf78dc7920
+    name: perl-experimental
+    evr: 0.022-6.el9
+    sourcerpm: perl-experimental-0.022-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-fields-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16096
+    checksum: sha256:c2f5157686257ca7b67e566b4d7e86116c6c8b9f590023adf84fde78d35d3ea9
+    name: perl-fields
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-filetest-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14556
+    checksum: sha256:4556ac1a93588b9b3e3722867ef73680028e53b3aae4af87165a1a70c79530b8
+    name: perl-filetest
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-if-0.60.800-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13876
+    checksum: sha256:ae3ce80bee55e1057ed004ec03a0e826b0cdd90ace4c0784ab2f569a2d81d40c
+    name: perl-if
+    evr: 0.60.800-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-inc-latest-0.500-20.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 27665
+    checksum: sha256:22c41d7117656dfff8d52bc8e557e6f8d11d2b5ed377173f56037a2ac8bc9139
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+    sourcerpm: perl-inc-latest-0.500-20.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 71956
+    checksum: sha256:8f17e4683b342e5d0e97406a4c464f6ba7a9b9deaf6e39ff36b5b1459daea162
+    name: perl-interpreter
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-less-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13074
+    checksum: sha256:8c69534a3a191e28647b5c201dce163f2fa30f0813d54ace2345bbab830d7a9b
+    name: perl-less
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-lib-0.65-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14815
+    checksum: sha256:ac5fca3480c9429a1c86b7a781a0713776a75719b9337297f602cfb9cd2eeb12
+    name: perl-lib
+    evr: 0.65-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 137289
+    checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
+    name: perl-libnet
+    evr: 3.13-4.el9
+    sourcerpm: perl-libnet-3.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libnetcfg-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16266
+    checksum: sha256:fcb262ee807d950b902ca12744cb2645c52de5aae0d9380a7ff4dd5574aec7fd
+    name: perl-libnetcfg
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libs-5.32.1-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2255446
+    checksum: sha256:63434fb3f9efb3417bb263c8b9e1590384e7124a094855e82d64655161eaff21
+    name: perl-libs
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-local-lib-2.000024-13.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 73510
+    checksum: sha256:c8f58afb9e8eb07bc57f92c384753ee4f4fec10fa7ec7c091ad9f15110a10026
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+    sourcerpm: perl-local-lib-2.000024-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-locale-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13543
+    checksum: sha256:6b81563677505210a973fd4416f5991bf729c03f3082ac139460290643daef33
+    name: perl-locale
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-macros-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 10568
+    checksum: sha256:e499fae237cea4dcec9480576b64c69afe91c09875a8dfcf9b4daebdbeb9f197
+    name: perl-macros
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-meta-notation-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9577
+    checksum: sha256:0b7fb715954c7f67719f00bc7323d4a12453aab37acadba5106758f864c8535a
+    name: perl-meta-notation
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-mro-1.23-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 27780
+    checksum: sha256:10e9c630c9628d189ff2d705f280498c83bc407a1fb03b11f4251973b7e46b51
+    name: perl-mro
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-open-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16407
+    checksum: sha256:f3e192485674a0681320f38c4163460ce0bf4855b7e825f75c371f3b3a7c778f
+    name: perl-open
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-overload-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 46157
+    checksum: sha256:f172df7417780cb61b879effe60ce6b7b4399773c46cb9896a5edf2bfba6dbda
+    name: perl-overload
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-overloading-0.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12747
+    checksum: sha256:4aae487e802df60e1e2d778b264592290ad492078877784771299561d45dfd47
+    name: perl-overloading
+    evr: 0.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 16286
+    checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
+    name: perl-parent
+    evr: 1:0.238-460.el9
+    sourcerpm: perl-parent-0.238-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-perlfaq-5.20210520-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 388755
+    checksum: sha256:e5588c37edf2bb614ffb7526deb663bc406effb86492637b4c906c5fe06f0b98
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+    sourcerpm: perl-perlfaq-5.20210520-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ph-5.32.1-481.1.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 41462
+    checksum: sha256:36d34c290cb0bf2ce127d5eeda3a2091c6e669bf47b5230f454879a241c00dc0
+    name: perl-ph
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 121317
+    checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+    sourcerpm: perl-podlators-4.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-sigtrap-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 15624
+    checksum: sha256:5b7215d5421f381137e867678492848574c2ceb58e56d47d7833d182923e92c6
+    name: perl-sigtrap
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-sort-2.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 13408
+    checksum: sha256:554155e6ff38d091ea388b1f19fc0b0950522b4c4ffe87cfee3676c4f03c046d
+    name: perl-sort
+    evr: 2.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9639
+    checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
+    name: perl-srpm-macros
+    evr: 1-41.el9
+    sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-subs-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 11525
+    checksum: sha256:0a7ef4a9a174ab981949d27a4acdc8cec87fd3513e9e607f5869851dc1c74deb
+    name: perl-subs
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-threads-2.25-460.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 61254
+    checksum: sha256:787a2ff27e96046c3b38e44a760e52660f6b63875661ef64addde79b63363eb1
+    name: perl-threads
+    evr: 1:2.25-460.el9
+    sourcerpm: perl-threads-2.25-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-threads-shared-1.61-460.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 47910
+    checksum: sha256:073ef01a23d905b89b5688645c85fa654567876c19043378b9fd15e44229c558
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+    sourcerpm: perl-threads-shared-1.61-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-utils-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 55943
+    checksum: sha256:5c21992a23a63139c0c73ce0b9866cd9064ab2efc8d9414bb45edc6c72996162
+    name: perl-utils
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-vars-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 12885
+    checksum: sha256:5d3c58094c0158b6193d7f4ba7a4bb7ae06a78738393b31255da8b7aadb10e38
+    name: perl-vars
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-version-0.99.28-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 67978
+    checksum: sha256:9b7761fa17fd29d8e6f80cfbf12c659cd90a133f5dfc813881473195e0a2a4ce
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+    sourcerpm: perl-version-0.99.28-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-vmsish-1.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14031
+    checksum: sha256:af9db38df1c1843277ebd8c6bb8d766017be043eea28246252788b055f19764d
+    name: perl-vmsish
+    evr: 1.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 77697
+    checksum: sha256:342fa73cc94923b8ce94c4dc6ecb6f8e489b1ecfc7574ed04b93824e061c1c57
+    name: policycoreutils-python-utils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pyproject-srpm-macros-1.16.2-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 14828
+    checksum: sha256:1bec3715412a73295a9cd2cdbc147ebee0fe23b50f4146bddc08a5761ed3928d
+    name: pyproject-srpm-macros
+    evr: 1.16.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 18705
+    checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
+    name: python-srpm-macros
+    evr: 3.9-54.el9
+    sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 80843
+    checksum: sha256:4fa25f9b72172ae3dad7863369dbbb1cee9add8a3c7ad779717013d93f891f1e
+    name: python3-audit
+    evr: 3.1.5-7.el9
+    sourcerpm: audit-3.1.5-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 191826
+    checksum: sha256:dcc609ec4df45a30606ce85999c9cf45e819d4f8e8479662dfaf6bfb1b27dd2d
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 82350
+    checksum: sha256:1a32b9c090a98ddffe5ef70e4485dae8c295d942d87e15753e1cb5f01e23bc97
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-policycoreutils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 2210974
+    checksum: sha256:db891ec3a74ccdd7ab2f9cf0a4436e7df3e6702eb483cd111421f79a334e4aea
+    name: python3-policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 9344
+    checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
+    name: qt5-srpm-macros
+    evr: 5.15.9-1.el9
+    sourcerpm: qt5-5.15.9-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/redhat-rpm-config-210-1.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 72050
+    checksum: sha256:ad59b922bf8028d3021c74123d33ef770a500dc7b0dd16a34301b0fcc09c6af4
+    name: redhat-rpm-config
+    evr: 210-1.el9
+    sourcerpm: redhat-rpm-config-210-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-1.88.0-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 28639155
+    checksum: sha256:ef479c53d6d2e75753f5d36661ec01746d70ad16dcbb82f51dc4296de8e32613
+    name: rust
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 11243
+    checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
+    name: rust-srpm-macros
+    evr: 17-4.el9
+    sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-std-static-1.88.0-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 39777482
+    checksum: sha256:9431bb9d0a3dd5fbfe3bfef2c28ef5149c72173ad53b75b046e1f4dad9d9d48d
+    name: rust-std-static
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 42050
+    checksum: sha256:b7c093e050e3d127b98bd1002e46dee9cfbbc6279978aee17d7fad30b42a41ec
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/sombok-2.4.0-16.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 51650
+    checksum: sha256:9ff787f7edde5ff05a3e86c55913cbb2ab0d2e38ba5c9a7e318ef621991b3b8b
+    name: sombok
+    evr: 2.4.0-16.el9
+    sourcerpm: sombok-2.4.0-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/systemtap-sdt-devel-5.3-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 70536
+    checksum: sha256:550d9cbd224cf899e4699cdf4aa24e093b3a46e6a8291de8d2e7c966c7ecf714
+    name: systemtap-sdt-devel
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/systemtap-sdt-dtrace-5.3-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 71458
+    checksum: sha256:60d435c02d8102ecab9182580236e7cc9026eac9a88bfaa49babed67b4b576b5
+    name: systemtap-sdt-dtrace
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-67.el9_7.1.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 5017674
+    checksum: sha256:5c26e9da5ebaf4d5feb38f117b4468c41ad0c66cd80e52a68a9c322abf2b04ba
+    name: binutils
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-67.el9_7.1.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 902260
+    checksum: sha256:a9e2c2aac2f03056149fb55ed37a0df540dd65c921612ef3cde3d899ea7d8224
+    name: binutils-gold
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cyrus-sasl-2.1.27-22.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 73758
+    checksum: sha256:a6e1920c9fd0bdf60d7473521928292ba436ad7a80d0fc93214212c165aaf5b5
+    name: cyrus-sasl
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 405687
+    checksum: sha256:524412f7ce56095508190116cb8ae141737857e4447979330c3cf75ca7017e6b
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.193-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 43664
+    checksum: sha256:f4eaff2bb0d77405c94e1877ae2dc3c741a5d06172ba75056af070b8c06b50a4
+    name: elfutils-debuginfod-client
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 605165
+    checksum: sha256:569419a5a9256714a4d0f665ff2bada6f565bcc104479115c584cdbe897cf6bf
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/file-5.39-16.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 53149
+    checksum: sha256:e82e23ca88067aa8d5b5b6adaa7a3500a0eb74e7612de35d1fb6b3b1df940aad
+    name: file
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-231.el9_7.10.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 1824070
+    checksum: sha256:d181ac8b41e7b184af5fa20494fdf467a585a508a274b3d3af39f34fcc3823e9
+    name: glibc-gconv-extra
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 1088949
+    checksum: sha256:452cfe5372c834bb174ef1f6eed4d0aa6179420fd572163467ac9036fc7a3a1d
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 50251
+    checksum: sha256:7c002eb9c81bad49b8a11d9790af6220cce5fb882be7ca11335882d079d1473f
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 165028
+    checksum: sha256:fa762484ba40e0b7eb1c25531a66a0b578b6141cabb6f73d865c13ccdf75c1c9
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-11.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 25815
+    checksum: sha256:dda1b97e44baf5b325bf556a0cf0cb38768d425d84467de0a18baa89cffc4166
+    name: libatomic
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 59368
+    checksum: sha256:93a2f44044ab11225b1123bc9df4f4d09c0a5f3251818e7d144ca64fd12c0957
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 107505
+    checksum: sha256:a56a79e2254db3d351dce58e9960921aec45715b6b7c93eb7a0f453d1e60bae4
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 100573
+    checksum: sha256:e56e963635b92f407471c7c5698d602135b135bda4515ecc75ac52dd1d38c7e4
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 52161
+    checksum: sha256:32d8aea6849a815e201cdce925fb3c6de2088cfcb7f6621e93495b605abe2f13
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 38310
+    checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 197588
+    checksum: sha256:63fc5e8f22ddff6ae1428b6802f7cfc4ef75c50199de107abecbff3937ad0c35
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 550249
+    checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/man-db-2.9.3-9.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 1233088
+    checksum: sha256:44d2f613bd962c7ddd7202780d648dbdb1c9030965c36e57e72ad7b2e56fd6e2
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-6.2-12.20210508.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 414136
+    checksum: sha256:70b5e65c332d9b68b005fa0b8e7d0b53deaa21c55833fa1bd5fed4985c2f95c0
+    name: ncurses
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-8.7p1-48.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 464217
+    checksum: sha256:bd9450a83d00d528e56191d05bc11ec94b616c13f8d89f02455c6fd060df8559
+    name: openssh
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-48.el9_7.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 703700
+    checksum: sha256:958e905253df69a927ceca84c0a2fdd75107b5cc3a244ae5ca45becb633765ad
+    name: openssh-clients
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 45196
+    checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 12398
+    checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/policycoreutils-3.6-3.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 244356
+    checksum: sha256:d57578bdc35f4bed8670d38112aaf6258898e77859bb35c73f911c5e08a3a331
+    name: policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 363344
+    checksum: sha256:a8c7514beb4c3cafa6341f43bbe285319d863b2893a34d91159dc8e90f615dd2
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 157800
+    checksum: sha256:4c7b1bbabe7f37d1dd098c9d893f7f8e97e5fd43aa8fa4d4c58a3b6b66e69c70
+    name: python3-pyparsing
+    evr: 2.4.7-9.el9
+    sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 613411
+    checksum: sha256:f8e347a37155ff1b805c7d7ed1ad98db8df8fdfcf3d04c13c819e796604c892f
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 1137015
+    checksum: sha256:a7cf45af14e65509a7f4d33422499372f6fb869bb82695dd4e9004e5c2e4ac1a
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/unzip-6.0-59.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 182284
+    checksum: sha256:dc0b3bbb5e028ae1473afac598705038bb166bf848a3b80e632950746c111ba0
+    name: unzip
+    evr: 6.0-59.el9
+    sourcerpm: unzip-6.0-59.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-23.el9_7.2.noarch.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 20860
+    checksum: sha256:e3fc2d706b1e395043a8a9bc76bb04c1ef7174269c840cb73176d00260df2724
+    name: vim-filesystem
+    evr: 2:8.2.2637-23.el9_7.2
+    sourcerpm: vim-8.2.2637-23.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zip-3.0-35.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 269791
+    checksum: sha256:4dfc9b2afc08b96cba0a8c7f06be5691ec26f2104d9c1a100aa0432e30aac3cd
+    name: zip
+    evr: 3.0-35.el9
+    sourcerpm: zip-3.0-35.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: ppc64le
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/annobin-12.98-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 1120549
+    checksum: sha256:78c2d06b7f077ad39e06dc03431fbfbfba3b7135db7788072c4625aefb8a5e06
+    name: annobin
+    evr: 12.98-1.el9
+    sourcerpm: annobin-12.98-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cargo-1.88.0-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 8432875
+    checksum: sha256:134bfbd26e53ff42298e65a0b4289982bd47fa1f87ad7ff223151522db928498
+    name: cargo
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/checkpolicy-3.6-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 392817
+    checksum: sha256:3aeb7587530a94dacfb0aa1653030df55173a73309f3ba25dfe3d34b2a0bbc59
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/clang-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 159863
+    checksum: sha256:b71cd9127b55424a42643ba92e3b73c3adf37db6e3fe86a20575e7f355a6a045
+    name: clang
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/clang-libs-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 30360599
+    checksum: sha256:7a086f7bb5ca0d8fad932964a17bc395be33d55fef6cf00ba519ac139766c2bb
+    name: clang-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/clang-resource-filesystem-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14980
+    checksum: sha256:4c76d1dbd928eca8d9da52461dd09cb4f45631fa899b0ccb4c955b71a20bc068
+    name: clang-resource-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cmake-3.26.5-3.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 10301647
+    checksum: sha256:47276164b1e074431390aabd24ec532694210f0a142e9ad3e606c1e546e5615b
+    name: cmake
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cmake-data-3.26.5-3.el9_7.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 2483069
+    checksum: sha256:6b8afdf96d315c36df391e0f170d5ba845d11704549c4ffa3533aa43922d722e
+    name: cmake-data
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cmake-filesystem-3.26.5-3.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18590
+    checksum: sha256:ffed21db461e57ab430297666ea64e9f6ced19bdb9e877c906476bc946ac72c2
+    name: cmake-filesystem
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compiler-rt-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 1743324
+    checksum: sha256:e2bb57a543ce64e49742c2d6dbcc8c9e699b96ba531e7a306312cc24f8ae6002
+    name: compiler-rt
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cpp-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9615628
+    checksum: sha256:4c0f188ff6fb0970e6b0da411d3ff2f8b4f89dd1b11b706982bea83231a717fc
+    name: cpp
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cyrus-sasl-devel-2.1.27-22.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 114363
+    checksum: sha256:3a9374fe6a7e72d868537851295473e3c289610e76422ca46defac8fc0b7ccac
+    name: cyrus-sasl-devel
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/d/dwz-0.16-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 143774
+    checksum: sha256:a1f7e2a307ab57323f10596b4d51ad8e4916a7109459677f26f4afef82b9c010
+    name: dwz
+    evr: 0.16-1.el9
+    sourcerpm: dwz-0.16-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/e/efi-srpm-macros-6-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21527
+    checksum: sha256:4cf4841f5c7145f3dce72175e09d39b02c7fbb44be552d9d407431a7a81ef9ef
+    name: efi-srpm-macros
+    evr: 6-4.el9
+    sourcerpm: efi-rpm-macros-6-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 30140
+    checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
+    name: fonts-srpm-macros
+    evr: 1:2.0.5-7.el9.1
+    sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 216324
+    checksum: sha256:f44a17730803f53266874678031b8121541b5b1a8047a3205c2576630216f468
+    name: gawk-all-langpacks
+    evr: 5.1.0-6.el9
+    sourcerpm: gawk-5.1.0-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 29067772
+    checksum: sha256:890d7ab6d0e5a3c409d94be2061722e28046d21e93e0c9b13e408ea1835bc192
+    name: gcc
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-c++-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 11746307
+    checksum: sha256:ff1cfa287ae2769c03ef1d3db744fe088651cbbf6bb1c3a1165f2724a3fc84e5
+    name: gcc-c++
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 39632
+    checksum: sha256:2b8e6fe148104d2739645d7f8207613bf8f889dd0fbebf4f403844c441071e6f
+    name: gcc-plugin-annobin
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-5.el9_7.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 7072196
+    checksum: sha256:cbb62c6abb6ac2075bff5f52eab171f662c140ef5b2d725d122e1654f494439a
+    name: gcc-toolset-14-binutils
+    evr: 2.41-5.el9_7.1
+    sourcerpm: gcc-toolset-14-binutils-2.41-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-12.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 42070236
+    checksum: sha256:d0ae17b42cc6b48d9ff893a090d578fa6e2322e68f0f2bdb04c42365b1d01db0
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-12.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13521362
+    checksum: sha256:80a6edbb9346459bb1ffaf2eec77827daabc69ebd7cb626c4cc0fe64832950e3
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-12.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 3995323
+    checksum: sha256:870393e745dfb4c1113691a94fc46afc998d4fb38bda21f818bc3af97d814184
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 58553
+    checksum: sha256:ee11750afda9e958bd21430e5fa02eee3066774e33079b8dee43837b647c84c8
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9252
+    checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+    sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-2.47.3-1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 51870
+    checksum: sha256:181b68bcece9039440f3b999ad30258ed5cbde2fdcdf948d3739c8f14f917c8b
+    name: git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 5417950
+    checksum: sha256:112407c6e8c561db49df6f45532795d2572e638a6e6db522d3371890b4b808e3
+    name: git-core
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 3195826
+    checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
+    name: git-core-doc
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-231.el9_7.10.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 588388
+    checksum: sha256:3e308099aef9d19160c4dc0652a0a377f6b9491d9bf8f9485efcd9c998ae0392
+    name: glibc-devel
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_7.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 33806
+    checksum: sha256:ea2a392fd650fc6c4928590af98a4b35f705537b0353417599ba97c21b271404
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_7
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 3008577
+    checksum: sha256:7eb6ce67e2ba48169392a4518c6941eeae855563070d07f6eaa831cf80606a74
+    name: kernel-headers
+    evr: 5.14.0-611.47.1.el9_7
+    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14098
+    checksum: sha256:54edccc470e78f835a572f809b11413bb62bc5ca765e523eaf17ca23cdde08d3
+    name: kernel-srpm-macros
+    evr: 1.0-14.el9
+    sourcerpm: kernel-srpm-macros-1.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libasan-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 440457
+    checksum: sha256:5cc55c4bc7a4bd7fae846063746472d146165a24e5e650fdd08b07db27421301
+    name: libasan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libdatrie-0.2.13-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 37292
+    checksum: sha256:224d0c986e1aff2772707bf354fcc462a1be4246b38a7f3c2aa8a44081213f06
+    name: libdatrie
+    evr: 0.2.13-4.el9
+    sourcerpm: libdatrie-0.2.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libmpc-1.2.1-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 71343
+    checksum: sha256:12c0bd83a7321dccd6c715d149cb6f12299e13a1e09732a629003b0140ad9b32
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libomp-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 749028
+    checksum: sha256:f45af78091cda60d084f987bee55b819506d84a106f011c3d3635b90b8dec27d
+    name: libomp
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libomp-devel-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 287542
+    checksum: sha256:b4769fa6b3dae9f1ac106a3d8bb4735101cfcec3cf7bd16a00985d632574aba9
+    name: libomp-devel
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libstdc++-devel-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 2525476
+    checksum: sha256:d8e3d2ee057a21b64cc69d71cdb2c5011d9dab2d3724d39db369ddd48c86d495
+    name: libstdc++-devel
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libthai-0.1.28-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 218246
+    checksum: sha256:f1cd77d5d8eebd82decc778b469196b20bf4f2d89b0204718690d810cc2244d4
+    name: libthai
+    evr: 0.1.28-8.el9
+    sourcerpm: libthai-0.1.28-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 41941
+    checksum: sha256:1aeb1dd5ed52720e71481871150b8feed52d0fed307d38fefb636a2065854107
+    name: libtool-ltdl
+    evr: 2.4.6-46.el9
+    sourcerpm: libtool-2.4.6-46.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libubsan-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 201436
+    checksum: sha256:907dc757f1457186a215a77d58b95b29a183ad951f5d1942a0459caeb65ffe64
+    name: libubsan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 163459
+    checksum: sha256:74d081a0b46ad47b150a99d788d7d408939ea0ce20ed0b14b34d0e41f2b6fcad
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 33082
+    checksum: sha256:0897868b5e5ab66225dd55f585076975a84e3fd68b93a38be1d8a231d441bc16
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/llvm-filesystem-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9353
+    checksum: sha256:7414ea19b1e878a85cd998f171975eca3acbef8a67a5f736d356b9c3febb92eb
+    name: llvm-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/llvm-libs-20.1.8-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 31687692
+    checksum: sha256:0edfc5b92d24341343278562fb738cf71b4d1b0f0522a295ce207b339e5b10f0
+    name: llvm-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 10476
+    checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
+    name: lua-srpm-macros
+    evr: 1-6.el9
+    sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9270
+    checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+    sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 8807
+    checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+    sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/o/openssl-devel-3.5.1-7.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 4996761
+    checksum: sha256:e80d9fa082234c8d941869ccbb7836761f7cc7c15a9211f56e8ad17fc79f4530
+    name: openssl-devel
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-5.32.1-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 8413
+    checksum: sha256:67a51d34ec7b9df81ce1ec84274f002d59e361d369194103c94acfd19ba8949d
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 52041
+    checksum: sha256:3d252e247a41978a10faef66931ac5fb2525c7fa708d8caa537d368ef5ba62ce
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+    sourcerpm: perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Archive-Tar-2.38-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 77744
+    checksum: sha256:5cf97230d350543cdf34f379dc04e1383f89591ad76768b5a2738b474cdec404
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+    sourcerpm: perl-Archive-Tar-2.38-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Archive-Zip-1.68-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 118766
+    checksum: sha256:2237a7cdfa30cda2ad475cb6ee5796f1e4cafa07e8760e08bca8d252cd6eb51d
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+    sourcerpm: perl-Archive-Zip-1.68-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Attribute-Handlers-1.01-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 27731
+    checksum: sha256:95ee8b22f5c962b56b95dc3e74280ed1471c17bb2031995d3efd431478e40aac
+    name: perl-Attribute-Handlers
+    evr: 1.01-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21344
+    checksum: sha256:b4557d853be8048aaefde5c4083c43fa34375e224731e93e584e4e3d5db46ac3
+    name: perl-AutoLoader
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-AutoSplit-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21714
+    checksum: sha256:de53b7057da078864d27f4acddf37594d40ee4d5f710d129c40cfb5c6097ceb0
+    name: perl-AutoSplit
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-B-1.80-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 187603
+    checksum: sha256:fdcea6cc274e768f593fc3387be82940ce6d593fff92f512d689dd1ddb691b2f
+    name: perl-B
+    evr: 1.80-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Benchmark-1.23-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 27055
+    checksum: sha256:690cc6ca69fd267f025ddc18116d8f10dff6693645ff949820c83ed7776aa454
+    name: perl-Benchmark
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-CPAN-2.29-5.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 589480
+    checksum: sha256:a46e7bb747f0b5dc26d8eda788b98492576048f5df271d070c35118f8d980b9d
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+    sourcerpm: perl-CPAN-2.29-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 17060
+    checksum: sha256:35687783ded44b01c37af59f66499b42e10df074c36608fc3f84bd4ae082c852
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+    sourcerpm: perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-CPAN-Meta-2.150010-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 210745
+    checksum: sha256:ec35026baabe720d7c880f896f84271f0c408c56d3fea6d7c5d22580ac175690
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+    sourcerpm: perl-CPAN-Meta-2.150010-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35205
+    checksum: sha256:eca17976f76fd8d31eda995a9ced2d813c1c94b9efafa1a83454fb120be62784
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+    sourcerpm: perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 29542
+    checksum: sha256:b21eb298e56bc6623257cae1434198789e80ab92b818af4e29514a7bbc6f5910
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+    sourcerpm: perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 32039
+    checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
+    name: perl-Carp
+    evr: 1.50-460.el9
+    sourcerpm: perl-Carp-1.50-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Class-Struct-0.66-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22220
+    checksum: sha256:d35ff343bd718fbd8531995a8aedb866c6d37fac6a688fcf9a458017781bf058
+    name: perl-Class-Struct
+    evr: 0.66-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Compress-Bzip2-2.28-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 77863
+    checksum: sha256:59aae3cf821dfd9f8e6d2df5048b1f767b451ec4870cea10656db2309263e38f
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+    sourcerpm: perl-Compress-Bzip2-2.28-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 39384
+    checksum: sha256:01544c88a64bbe65741fe5bad0e2861b35aca3287c0a7107945749e3a8311243
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 56648
+    checksum: sha256:5a9133be53f07c8d410a4c3cc63962065b20055219f0b6aed3864914733c6670
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+    sourcerpm: perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 65982
+    checksum: sha256:80db90508c36cda2ab4c6bd7b436b812ce4997f891c33325a58050b55ce306e8
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Config-Extensions-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12128
+    checksum: sha256:86695c36cd0bd3516cdb72d9f30ddec6aef47eb48432a76b71d15372e86549a6
+    name: perl-Config-Extensions
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Config-Perl-V-0.33-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 24943
+    checksum: sha256:7ec321ecb6f37b6be09ad182cb66fdeee9f12138f75fc48858bde2177c358d1d
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+    sourcerpm: perl-Config-Perl-V-0.33-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-DBM_Filter-0.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 32009
+    checksum: sha256:2ea4092322228a400fe8ad6c19302878e46771cbc1a2d623371c49732ad5e018
+    name: perl-DBM_Filter
+    evr: 0.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-DB_File-1.855-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 86611
+    checksum: sha256:3871fd41295faa976d3b72fbeb6004e3cf55cc6df105af9f2251fe7923621e21
+    name: perl-DB_File
+    evr: 1.855-4.el9
+    sourcerpm: perl-DB_File-1.855-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 60918
+    checksum: sha256:ddd2f1958bd1a5e0c555ef401a04800d72b9807e11c2a3d76af004f0a38d5985
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+    sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Data-OptList-0.110-17.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 30694
+    checksum: sha256:1455a3e90116f504008f8d27db57acb65c3389440dc6e2d605f54bf40b009a10
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+    sourcerpm: perl-Data-OptList-0.110-17.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Data-Section-0.200007-14.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 28030
+    checksum: sha256:9fb57b4fbcfea93de114505082261abd97f576cf78e1a205c255d69d8eb6babf
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+    sourcerpm: perl-Data-Section-0.200007-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Devel-PPPort-3.62-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 221883
+    checksum: sha256:e6e0bc019168bcc8eb442adb7dbcb4ccc3436b5c26ff80a82fba48959a43382a
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+    sourcerpm: perl-Devel-PPPort-3.62-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Devel-Peek-1.28-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 32876
+    checksum: sha256:c704fc2d463c0eef76d70572cad2a10ebbd966ce096957c924f18479951cd117
+    name: perl-Devel-Peek
+    evr: 1.28-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Devel-SelfStubber-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14231
+    checksum: sha256:703faaef6ca5a65ed4c3cbdb256da9612eed842bd77620a2d527ca8d0fa8a7d2
+    name: perl-Devel-SelfStubber
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Devel-Size-0.83-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35539
+    checksum: sha256:c85518071ddb9eeff2e9250dfb990e1aa486c980f88e9d968c4b8632d213b38a
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+    sourcerpm: perl-Devel-Size-0.83-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 29409
+    checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
+    name: perl-Digest
+    evr: 1.19-4.el9
+    sourcerpm: perl-Digest-1.19-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 40716
+    checksum: sha256:4ef3aef6190cf64e16f9c784e2b1560a51aac62b4381cef7492c8042e4122273
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+    sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Digest-SHA-6.02-461.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 70156
+    checksum: sha256:4e1188a0cf126748d1820b2bfb4d8bd3caf0ff525bb8d66b4a902f0bb38bc395
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+    sourcerpm: perl-Digest-SHA-6.02-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Digest-SHA1-2.13-34.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 57834
+    checksum: sha256:c8dc616512431a26efffb79191b1b81c528d17ad09f48d27cb22c9b5147450f3
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+    sourcerpm: perl-Digest-SHA1-2.13-34.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-DirHandle-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12337
+    checksum: sha256:2c79a7d1c783c4eb4305e7b15c885c7afc5e2612ab4b1245f4f9ef8dcff4804f
+    name: perl-DirHandle
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Dumpvalue-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18343
+    checksum: sha256:7659f1dab24e96da4be5624f90a3ac04b383071a96a32e185b196bc527377e1c
+    name: perl-Dumpvalue
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-DynaLoader-1.47-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25936
+    checksum: sha256:d40baa9bec3e963e77a9a65c1ed7c42ece796c367422b3f7c250ea204b3b707a
+    name: perl-DynaLoader
+    evr: 1.47-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Encode-3.08-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 1818588
+    checksum: sha256:000879773b1a093fd747fae52a31a6d866339a2091a6b94251fb64bb29778da5
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Encode-Locale-1.05-21.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21500
+    checksum: sha256:58afacf30f4a476f4ba6646a6419122d2a729bd59880611b631527502dcdc269
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+    sourcerpm: perl-Encode-Locale-1.05-21.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Encode-devel-3.08-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 45161
+    checksum: sha256:0f4ac45f6b5ca0340e73584ece54bcfa5a8efb73ba9fef9d8013a8577c6bad18
+    name: perl-Encode-devel
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-English-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13497
+    checksum: sha256:04a48f25493933a3ae04eac446efefa1d4c092e323db1561e7653e4f570987da
+    name: perl-English
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Env-1.04-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22160
+    checksum: sha256:92fb2287084a3c88a6b2d2bd300d1279251cec59156c1a9a3e0fa8fda6c546b2
+    name: perl-Env
+    evr: 1.04-460.el9
+    sourcerpm: perl-Env-1.04-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Errno-1.30-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14845
+    checksum: sha256:fb1d48a441f0a9e096d56083ec558b82e9c94c38ac17b4f60c5bf612e63f19cb
+    name: perl-Errno
+    evr: 1.30-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 47552
+    checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
+    name: perl-Error
+    evr: 1:0.17029-7.el9
+    sourcerpm: perl-Error-0.17029-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 34509
+    checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
+    name: perl-Exporter
+    evr: 5.74-461.el9
+    sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 54624
+    checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+    sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16489
+    checksum: sha256:642338ff95d94e2c6e4b7de47cda7b772d1fbc204b2869925bd0326fcc4b0e26
+    name: perl-ExtUtils-Command
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Constant-0.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 47285
+    checksum: sha256:f10abe9f8d9f26c2ef2f278baf37a98e7a654cf192521d72bb797a3ef2131698
+    name: perl-ExtUtils-Constant
+    evr: 0.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Embed-1.35-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 17684
+    checksum: sha256:10fa80d9248c159ad12cce5222d3d1b82953ddfc7c4123ca0b14b5d5340e1421
+    name: perl-ExtUtils-Embed
+    evr: 1.35-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Install-2.20-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 48441
+    checksum: sha256:2533a1d97d45dc79c07cc51409c34f188c042757a2811b04dc16892ae2c7443e
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+    sourcerpm: perl-ExtUtils-Install-2.20-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-MM-Utils-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14176
+    checksum: sha256:51d7199c10886580e6cbff82546a34f26b2d5b894dcc338e28b1b55938f50ae3
+    name: perl-ExtUtils-MM-Utils
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 311769
+    checksum: sha256:2286e5004cb6436b7ac8dd436c91b4e1d36c18b9385d07a24fc167c930c9dee8
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 37829
+    checksum: sha256:f7cf7fd259fb8a6c27537dc98e1ed4923b26c2d8d8fd6b789e166ac104cac5bc
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+    sourcerpm: perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-Miniperl-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15171
+    checksum: sha256:6b00fb367aea4654a14495802d46daa87d2e51ee203a8b0e207edae507773edc
+    name: perl-ExtUtils-Miniperl
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 194711
+    checksum: sha256:bb7e4bcfe24371bbe202a9fa704360a7bbc5d9f4103ec36e6e571da6eb76a186
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+    sourcerpm: perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Fcntl-1.13-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 20673
+    checksum: sha256:9da55c29f8d7c277aac1ffff6e1469e6292a2f9bfd3ac7e91ea1ce29012a0c1b
+    name: perl-Fcntl
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Basename-2.85-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 17211
+    checksum: sha256:e39dcc13a24d3b5a7ba11288e63b22a055a8e1061743b8a409858d98ebd794e4
+    name: perl-File-Basename
+    evr: 2.85-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Compare-1.100.600-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13166
+    checksum: sha256:0dd800746b848a84fce73dcef035c4241e6aa90262c821a0ad295a7756ca1a4c
+    name: perl-File-Compare
+    evr: 1.100.600-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Copy-2.34-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 20143
+    checksum: sha256:165816db79e88e63c96bdafaf0c3bfee95b6feedb78e40da3a6dcc196a15a186
+    name: perl-File-Copy
+    evr: 2.34-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-DosGlob-1.12-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 19621
+    checksum: sha256:abb702eae88d180e1fc8a3d6d81f4acdaa00c42c3a82fb065a8ff2f4b652c52c
+    name: perl-File-DosGlob
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Fetch-1.00-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 33372
+    checksum: sha256:8c46735b0f703cd53fbaf915423b63baf98701d81406b30b84e42e53a0efbb6e
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+    sourcerpm: perl-File-Fetch-1.00-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Find-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25551
+    checksum: sha256:002ec6d107fff6949f1a88965fb31b0a4efe6ce663395ab47e0cb939e3920c08
+    name: perl-File-Find
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-HomeDir-1.006-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 65857
+    checksum: sha256:68f539b86abb7ab910286188ad3742f4338330f3246f6da07cb4ca5c83d8e80f
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+    sourcerpm: perl-File-HomeDir-1.006-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 38466
+    checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
+    name: perl-File-Path
+    evr: 2.18-4.el9
+    sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 64150
+    checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+    sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-Which-1.23-10.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 24163
+    checksum: sha256:80a41f9f823312dca2c9fed97f6568a88957572277b75920fb76f20a60902e7f
+    name: perl-File-Which
+    evr: 1.23-10.el9
+    sourcerpm: perl-File-Which-1.23-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-File-stat-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 17117
+    checksum: sha256:b235134c1961e9b57f86bddc02e874607c17c155d2aa5ad78cc3ed9c8fd9c95b
+    name: perl-File-stat
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-FileCache-1.10-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14640
+    checksum: sha256:0b0ab9a79395bb7a926ec674b66f42845580903f514c511da156ffd497205f42
+    name: perl-FileCache
+    evr: 1.10-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-FileHandle-2.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15452
+    checksum: sha256:c2139abdb9b3335f592aa2835ef6d6fcde1e89232eb3d3c5a15f7cc1d0829f8d
+    name: perl-FileHandle
+    evr: 2.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Filter-1.60-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 98122
+    checksum: sha256:3a3eb5cc27ea848a23d7eef11dc952da70906ca8dd1cae7cc257c10077003dc3
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+    sourcerpm: perl-Filter-1.60-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Filter-Simple-0.96-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 29899
+    checksum: sha256:080a1c4c16acddca179c0e2ab8120fe01e374bb86d0a950923a610e50fabfc00
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+    sourcerpm: perl-Filter-Simple-0.96-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-FindBin-1.51-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13872
+    checksum: sha256:44f9c97a57dafae68f8183d1ca2682a8308b68f1a399ab333a3dd52836bb6b17
+    name: perl-FindBin
+    evr: 1.51-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-GDBM_File-1.18-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22276
+    checksum: sha256:edd913f883645da63266386341c27c963c0c0819a0aa53b87d7e8287eb3b5547
+    name: perl-GDBM_File
+    evr: 1.18-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 65144
+    checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+    sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15551
+    checksum: sha256:49bd8381823d680d17c37f3bebfd97dd92bfbf59e8019f15c7606f41dca02a7d
+    name: perl-Getopt-Std
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 38720
+    checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
+    name: perl-Git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 58720
+    checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+    sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Hash-Util-0.23-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35529
+    checksum: sha256:73316c13ec4aaf43e023d20f9c2f0802aa3d16cac7deac272263667b8e359592
+    name: perl-Hash-Util
+    evr: 0.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Hash-Util-FieldHash-1.20-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 39126
+    checksum: sha256:1330ad2f5910c9316245fc15f57d1d4f7d0952642be1fb3e78f663080a707027
+    name: perl-Hash-Util-FieldHash
+    evr: 1.20-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-I18N-Collate-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14091
+    checksum: sha256:82a82eb1e6765c7b4ec245a624f34e73d6a7b2c9c15a90007bcbb64113332793
+    name: perl-I18N-Collate
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-I18N-LangTags-0.44-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 55212
+    checksum: sha256:f0849fe10730cf503bebfbd82e3dfb39d64ef87667ee9a1a073df8fd231878d6
+    name: perl-I18N-LangTags
+    evr: 0.44-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-I18N-Langinfo-0.19-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22780
+    checksum: sha256:8962a5620c0859434034e904a890de5f23d161bdc91611f13bf718efd9a482d4
+    name: perl-I18N-Langinfo
+    evr: 0.19-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-1.43-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 90947
+    checksum: sha256:5231915b4841aa0d9db120885082130439fcaa597f1efb6e3617bdb958913224
+    name: perl-IO
+    evr: 1.43-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-Compress-2.102-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 280708
+    checksum: sha256:ce8f2004395442fe663cb9efc56f9af2102c75d746f2ce393e40af8a26ac6871
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+    sourcerpm: perl-IO-Compress-2.102-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 84153
+    checksum: sha256:bda4c005c09e886ce2273a3f418f0cd92521ed0b8fdcdaca7b9fc0026f2a6c7b
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+    sourcerpm: perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 46457
+    checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+    sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IO-Zlib-1.11-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21809
+    checksum: sha256:87d7b757a570fb53d72b2dd29558c2b4a8ff33196a80ad10f76999325acaec07
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+    sourcerpm: perl-IO-Zlib-1.11-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IPC-Cmd-1.04-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 42803
+    checksum: sha256:353b04bed7229ce354a4d63ba213c4e18fe739c4732061957946b84853d5b3ce
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+    sourcerpm: perl-IPC-Cmd-1.04-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22968
+    checksum: sha256:7ea36dcf28da3fc7250eb041ba19f99c87543c0870f5da67da614f5ca8d18b92
+    name: perl-IPC-Open3
+    evr: 1.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IPC-SysV-2.09-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 48892
+    checksum: sha256:526ac7c5a4e56ddbfca90e80249e387177ac91f146564a5ec3d6ee92829f0363
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+    sourcerpm: perl-IPC-SysV-2.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-IPC-System-Simple-1.30-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 44255
+    checksum: sha256:35792b1aa241cb17b881b1e44940bc295329a575a2a2d183757ef1d757062465
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+    sourcerpm: perl-IPC-System-Simple-1.30-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Importer-0.026-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 42526
+    checksum: sha256:1afb9008ad841ba4fc207af8ec814d06bd78e958cd2b03089c7b82c71a311060
+    name: perl-Importer
+    evr: 0.026-4.el9
+    sourcerpm: perl-Importer-0.026-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-JSON-PP-4.06-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 70596
+    checksum: sha256:17f547d40976904eb59449f0cdec890e34632a28a083fc46157ac1c67e9e3494
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+    sourcerpm: perl-JSON-PP-4.06-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Locale-Maketext-1.29-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 101003
+    checksum: sha256:97cfef112a414049f85495cbec570b8c63d7260410f72cb2e1480a67fc7e9e68
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+    sourcerpm: perl-Locale-Maketext-1.29-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Locale-Maketext-Simple-0.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 17604
+    checksum: sha256:206fca125c5520e6e0723c6f8ee4c9b56d5bec95c7d71e4b54fdad36ddf20980
+    name: perl-Locale-Maketext-Simple
+    evr: 1:0.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35880
+    checksum: sha256:c2f794f16a865b6ec6c0379c8dc09a0227e52fca37158543a0011ed22d29c366
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+    sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-MIME-Charset-1.012.2-15.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 54488
+    checksum: sha256:cf481c2178bc2a55c5b455749f38f4f96ee71f32dcf458c34d4f1bbcb996feca
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+    sourcerpm: perl-MIME-Charset-1.012.2-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-MRO-Compat-0.13-15.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22804
+    checksum: sha256:7921d8fd6d4dacdfb4a286fe4355516f20d660681abb49af9983f7527429e351
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+    sourcerpm: perl-MRO-Compat-0.13-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 198900
+    checksum: sha256:b90555cc3da95e314e931de2348d7c89da7c16023fb9399cdfbbcf9f1aeade7d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+    sourcerpm: perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 33416
+    checksum: sha256:f52941ea0f500efb0563385f66888889be59913fb0f5f7c930448f64b1084d5c
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+    sourcerpm: perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Math-BigRat-0.2614-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 42414
+    checksum: sha256:c31888896769451095c352ea97a1c88e2bbbc27d5bdc1e018dc8bae680967fb0
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+    sourcerpm: perl-Math-BigRat-0.2614-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Math-Complex-1.59-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 47421
+    checksum: sha256:754d5798c9a2bb21714671fdf0236e5937511bf59c473fdef8117c512410e8b5
+    name: perl-Math-Complex
+    evr: 1.59-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Memoize-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 57798
+    checksum: sha256:f668ee6ce94bab8e3a926587a1ab2f4ed3a4490d911c2e7fc1b2fe074a6cfdcc
+    name: perl-Memoize
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Build-0.42.31-9.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 274094
+    checksum: sha256:9e33e1a46048d262ebe06f98c6c7b1579cdf92db57b0bb4228d13883c232d82c
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+    sourcerpm: perl-Module-Build-0.42.31-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-CoreList-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 92615
+    checksum: sha256:fe85ea513ac696ce4d4bd5565259d89edde346d5a049d0eed153eac988ef73fd
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-CoreList-tools-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18135
+    checksum: sha256:2df9f5a5329e94c19bab88ba530149a86438756c7404787b03745f711adf3368
+    name: perl-Module-CoreList-tools
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Load-0.36-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 20052
+    checksum: sha256:ada066ac44fd73ec87ea376a6d6715cf77b086354217fdc7a197c909da3bb099
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+    sourcerpm: perl-Module-Load-0.36-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25464
+    checksum: sha256:58a5364d77607678e4e628f5bdd3d33641e2f6083c2985c1bc5045401ae65a60
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+    sourcerpm: perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Loaded-0.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13245
+    checksum: sha256:5873834f46d56066cab07a5386daccf8b4db7ccf23344967dcdc31a893907778
+    name: perl-Module-Loaded
+    evr: 1:0.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Metadata-1.000037-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 39221
+    checksum: sha256:f053b34c911e5f3daf16c0ffc5ff752f47a0d016e1cc1ac51d4425fbe2a1ac15
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+    sourcerpm: perl-Module-Metadata-1.000037-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Module-Signature-0.88-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 89282
+    checksum: sha256:1a173631124cdb77ffa2cb11ceb8de813f6e4222e5bf9ae657947211480858e6
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+    sourcerpm: perl-Module-Signature-0.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14781
+    checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+    sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-NDBM_File-1.15-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22087
+    checksum: sha256:0cb30732929ccd1ede53423b16aae24e014f199258193767d0a4d3c0abcb0841
+    name: perl-NDBM_File
+    evr: 1.15-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-NEXT-0.67-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21043
+    checksum: sha256:30c7f7f97f369fb9264c0c01f7f12fe1791c99e920aebdf149d71f945f814ec6
+    name: perl-NEXT
+    evr: 0.67-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Net-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25539
+    checksum: sha256:2bb0dceeec12a995caf29411056c2108a6f09b6bbe6d31090114fa4cbec53454
+    name: perl-Net
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Net-Ping-2.74-5.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 53027
+    checksum: sha256:fb74fb2651f62421538bb05992af5251887013a72c4412f5c2421992204c03bc
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+    sourcerpm: perl-Net-Ping-2.74-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Net-SSLeay-1.94-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 433117
+    checksum: sha256:36ce53a600231df7300e417250460b761e72637a831e544bbbd264c8a4fff339
+    name: perl-Net-SSLeay
+    evr: 1.94-3.el9
+    sourcerpm: perl-Net-SSLeay-1.94-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ODBM_File-1.16-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22195
+    checksum: sha256:81b2c1e169a1722f79537601b8f00a620082a1ac66f84ab7210c137697d7eaf3
+    name: perl-ODBM_File
+    evr: 1.16-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Object-HashBase-0.009-7.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 28938
+    checksum: sha256:2144d4c29ea4acfc0d872bf09cb4d9dce14a64e60a45633f1a31ed3a2b125ee8
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+    sourcerpm: perl-Object-HashBase-0.009-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Opcode-1.48-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 37551
+    checksum: sha256:9e42fa90dddb864332c646c98d191855633e41e03ea51b51d5062bb0913c7e5e
+    name: perl-Opcode
+    evr: 1.48-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-POSIX-1.94-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 100733
+    checksum: sha256:4a298844ac9b882ad51b8d34ec34d03683b52698ac67d214a8d5bee022d82284
+    name: perl-POSIX
+    evr: 1.94-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Package-Generator-1.106-23.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 26822
+    checksum: sha256:2c9b4699185c30d1da293add16911555e93b7532d77e59aa07e2c9c8d8eafcf3
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+    sourcerpm: perl-Package-Generator-1.106-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Params-Check-0.38-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 24764
+    checksum: sha256:a6cf1009e3f1dfe50e00421b11d43c413e7e4ee8c6931195256a3cb40e1baf7b
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+    sourcerpm: perl-Params-Check-0.38-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Params-Util-1.102-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 38568
+    checksum: sha256:58444f08aa2a804e6c7e91e87dda8839d4c1c8f3f4390d2206aabea29e6b012b
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+    sourcerpm: perl-Params-Util-1.102-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 95133
+    checksum: sha256:13167c7dcf4ecbc9136f0f1ea6923f1abf67f59f520fccd22cd462cf7c4eeaee
+    name: perl-PathTools
+    evr: 3.78-461.el9
+    sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Perl-OSType-1.010-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 26284
+    checksum: sha256:64f37a98e22fce4ee9520da6db13ab601e21e34ac9d3ae7f85fc7a63761c492b
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+    sourcerpm: perl-Perl-OSType-1.010-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25566
+    checksum: sha256:31d1284cda8a84f78574ae2380474412788de756613bcb11a85d68c94af9ba0b
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+    sourcerpm: perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Checker-1.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 35171
+    checksum: sha256:7410aed54bb1c0a18b7b0ec33b6067475383b557defdd295b48b3277229d31a1
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+    sourcerpm: perl-Pod-Checker-1.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 22564
+    checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+    sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Functions-1.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13531
+    checksum: sha256:8afc31372f05f71a11054c7d7318301d3d65547abc7eac3ed56d428843edae0c
+    name: perl-Pod-Functions
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Html-1.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 26780
+    checksum: sha256:f692dea024e6ced870a5f792db9e76e06d810dfce9846bb59e5b4442b28820e6
+    name: perl-Pod-Html
+    evr: 1.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 93727
+    checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+    sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 234403
+    checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+    sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 44477
+    checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+    sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Safe-2.41-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25188
+    checksum: sha256:ca9095157a26e3ee611c9b9ef6c075086a2381571fccc1a45ade5f8f88c5a78e
+    name: perl-Safe
+    evr: 2.41-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 79754
+    checksum: sha256:1548e1dc1a3e6c35a0a3065bd9ff1b9c7fc6f2c028c03e2f59fd7319a87b65de
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Search-Dict-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12900
+    checksum: sha256:f57497238bbc4edb96b24f88084e5d21f4e3aebab5d33a6db5e79a2ea53ce70d
+    name: perl-Search-Dict
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-SelectSaver-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 11553
+    checksum: sha256:8ec404df551d6cc4750efa34b9897d2288d07a26d49cd3d3d2315584976932b0
+    name: perl-SelectSaver
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-SelfLoader-1.26-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 21729
+    checksum: sha256:18a1b56a5a1097748cc998cb5305f5d77e253a05bae807b418694805fc413c8e
+    name: perl-SelfLoader
+    evr: 1.26-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Socket-2.031-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 60171
+    checksum: sha256:b18817cb936f736231166872928ac4a10418b42e9baeeeb93a4304d1764c0530
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+    sourcerpm: perl-Socket-2.031-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Software-License-0.103014-12.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 147494
+    checksum: sha256:c225b78b513fc8b90a0b2b773fadcf65dd2defe2a147fca67c52971d2750f437
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+    sourcerpm: perl-Software-License-0.103014-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Storable-3.21-460.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 103710
+    checksum: sha256:55e3f3536cad3677ee99ac54705dc6075fc938e17b453410ff383932fc93c6da
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+    sourcerpm: perl-Storable-3.21-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Sub-Exporter-0.987-27.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 78523
+    checksum: sha256:4e2535cd4d456f91f346e6d690c9a22c4b2a01318f9a5b5f761e1170d815bed1
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+    sourcerpm: perl-Sub-Exporter-0.987-27.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Sub-Install-0.928-28.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25233
+    checksum: sha256:4ce03d243d1331188c5a2b0e4103dad6b930ba36362cd353f0f3cd0998784e82
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+    sourcerpm: perl-Sub-Install-0.928-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Symbol-1.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14061
+    checksum: sha256:aa9942be4c837c024c6a0a376b13f9563e16ee8b66631ad6c5ff35cd0124728d
+    name: perl-Symbol
+    evr: 1.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Sys-Hostname-1.23-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16932
+    checksum: sha256:68721c205c411b6494b21ccb4440975181400a82b3d3ac758be2bbcee9a7d4bc
+    name: perl-Sys-Hostname
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Sys-Syslog-0.36-461.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 52779
+    checksum: sha256:201e68a9eaa947f8eeb6b6e9a3e41999957f4b761537e36b7eed1c7bf207329d
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+    sourcerpm: perl-Sys-Syslog-0.36-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 52228
+    checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+    sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25043
+    checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+    sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-Complete-1.403-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12886
+    checksum: sha256:fe5f8688a2a28327a35be1caa35a9d7b8718531120ddfdb10da6f80d6b577059
+    name: perl-Term-Complete
+    evr: 1.403-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-ReadLine-1.17-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 19061
+    checksum: sha256:506c2fb3304f36ce437696dea9fb8772424a08345c765b25ac7278e429df1dcf
+    name: perl-Term-ReadLine
+    evr: 1.17-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-Size-Any-0.002-35.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16309
+    checksum: sha256:e83c29bb60e3fdac1c7aa5d3cde8a6b237812a14fe8f711bf6e127ed96d929a4
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+    sourcerpm: perl-Term-Size-Any-0.002-35.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-Size-Perl-0.031-12.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25223
+    checksum: sha256:b7f29f264abaabcf702cd813de920cd8c4807377e4e753db25934b42125779a0
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+    sourcerpm: perl-Term-Size-Perl-0.031-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Term-Table-0.015-8.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 40852
+    checksum: sha256:3e0c26e1b0e31d17cc133829ad8d6e22c86e532e9b6a3c26f48b7ec447bdfbb4
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+    sourcerpm: perl-Term-Table-0.015-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 41994
+    checksum: sha256:c94ebcc34f23bd1caef2e64456c47a9a5bc21de163719fa6bdefaeceeec5f435
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+    sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Test-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 28830
+    checksum: sha256:879484e27419a62c5eb942327570be90f246334000d9e3af1e052155b6e08661
+    name: perl-Test
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Test-Harness-3.42-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 306138
+    checksum: sha256:7980ae9e28aed0aadef4f169e8479812a2a6bacf05ee53001f63d021b065fe40
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+    sourcerpm: perl-Test-Harness-3.42-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Test-Simple-1.302183-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 645034
+    checksum: sha256:04ae40e07d57934e5dc3946fa638023ee76305dac04bed7813ed338b0a4c2ef2
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+    sourcerpm: perl-Test-Simple-1.302183-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Abbrev-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12026
+    checksum: sha256:7671d9b159be320b1725a11b9ba5a9d15b809ec22ba13e0ae5cacf5ed09fdec1
+    name: perl-Text-Abbrev
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Balanced-2.04-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 51500
+    checksum: sha256:67ff60f60b6dc900e840ed51ff3b1cabef9e43aa48cba81ad97ae9423bdca5af
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+    sourcerpm: perl-Text-Balanced-2.04-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Diff-1.45-13.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 45523
+    checksum: sha256:5141fc840dc2989b44df904df2cadfdc3b6b9d38a7e4dba2c2db3c14e3dbc060
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+    sourcerpm: perl-Text-Diff-1.45-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Glob-0.11-15.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15921
+    checksum: sha256:079d5eb4a606a131eaeecfcbd7f7d39a21c9c49b97bd6b84f7d08986dd11dc59
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+    sourcerpm: perl-Text-Glob-0.11-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18680
+    checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+    sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25935
+    checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+    sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Text-Template-1.59-5.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 64485
+    checksum: sha256:3c7350777e9d26fe4c02d52e8c4d4e0643ee32f8abfb9e22fc28f5325702924e
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+    sourcerpm: perl-Text-Template-1.59-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Thread-3.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18018
+    checksum: sha256:0caef6e47205d0035b3f692010e9f7dcd710e7832da77a2a5abbe930440f7e48
+    name: perl-Thread
+    evr: 3.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Thread-Queue-3.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 24804
+    checksum: sha256:88d838d681ad683970eb8566e8936faabffc3495dd1b555f083a1cd00538291a
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+    sourcerpm: perl-Thread-Queue-3.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Thread-Semaphore-2.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15604
+    checksum: sha256:136b09ee2841a1b6655f0a29759fe353b7f4b12ea3e559bafd39d4c508644925
+    name: perl-Thread-Semaphore
+    evr: 2.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Tie-4.6-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 31837
+    checksum: sha256:7144466ebb0d8dc2b7af2deac1dddd8caa23b35bcc0d42829c9b242b18f39d6c
+    name: perl-Tie
+    evr: 4.6-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Tie-File-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 43818
+    checksum: sha256:f99032921dc45c8a77f91909b5329a95fc4bade37815e2e866c70bf6f39a7c82
+    name: perl-Tie-File
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Tie-Memoize-1.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14038
+    checksum: sha256:1f3395cf1a045adfabf0e9b82bc4676f0dd1d76a985afedb3e069e6e9128c677
+    name: perl-Tie-Memoize
+    evr: 1.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Tie-RefHash-1.40-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 26260
+    checksum: sha256:5519a86c145d83a1633a127f7b0b6a371e6b2b8a647dabff45c2754388504a44
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+    sourcerpm: perl-Tie-RefHash-1.40-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Time-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18651
+    checksum: sha256:e23d1ba4c2e8d4283e757a7af563a24038b5829ed55c9bc90b4bae8c498ec5d7
+    name: perl-Time
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Time-HiRes-1.9764-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 63586
+    checksum: sha256:003e02cb9545febcb5dcdf2d6be57db97ca824ebeb564aa4679439f9780e19ec
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+    sourcerpm: perl-Time-HiRes-1.9764-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 37469
+    checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+    sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Time-Piece-1.3401-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 41585
+    checksum: sha256:502f0aef50683385dd36d34c5bf890cf219fc37bc5c33772805f8425bc151dc2
+    name: perl-Time-Piece
+    evr: 1.3401-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 128279
+    checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
+    name: perl-URI
+    evr: 5.09-3.el9
+    sourcerpm: perl-URI-5.09-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Unicode-Collate-1.29-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 761686
+    checksum: sha256:0f4b8b519a674352831624e321a763224d026c638498233c8ebeaf782de50783
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+    sourcerpm: perl-Unicode-Collate-1.29-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 133600
+    checksum: sha256:2cf7d61aa52c26e77c083b5781c6b7c7c61c0a08478c4979bf0224111cd0f2fe
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+    sourcerpm: perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Unicode-Normalize-1.27-461.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 95527
+    checksum: sha256:ee1b4f9b92a81d0ced5a3d45fb743d812505fb296889ea805a057ff158e9c2f2
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+    sourcerpm: perl-Unicode-Normalize-1.27-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Unicode-UCD-0.75-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 79927
+    checksum: sha256:208f347f513df7c59ab77d90b54d3c9ed4cf67e733887783354a2c6ebeaf6409
+    name: perl-Unicode-UCD
+    evr: 0.75-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-User-pwent-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 20597
+    checksum: sha256:f131ac194a35b3b17f5ff6961e9bb9eb031fd5c7d0055e05a438c11b53931263
+    name: perl-User-pwent
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-autodie-2.34-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 103286
+    checksum: sha256:8c4a7c8fd5074801946cce0b0b2f47337036e7f64e4cb9c833d9cf1de1f14edc
+    name: perl-autodie
+    evr: 2.34-4.el9
+    sourcerpm: perl-autodie-2.34-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-autouse-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13668
+    checksum: sha256:c2502f538edef3d9b9ad20cdc8c0f8e971ac651df6c07f8555aa315b602c085a
+    name: perl-autouse
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-base-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16220
+    checksum: sha256:0be44f055107893b011ed0e88f39ff202ba451db8a94351ad4472d350c780d0d
+    name: perl-base
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-bignum-0.51-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 48635
+    checksum: sha256:a25963adbb78901e2581a041252bfc96f55e534403e4af513d8728c62f0b4800
+    name: perl-bignum
+    evr: 0.51-460.el9
+    sourcerpm: perl-bignum-0.51-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-blib-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12267
+    checksum: sha256:50560de5f252c718728c45cb7af3742252581416e0acb9cfacd686dad58c0028
+    name: perl-blib
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 25865
+    checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
+    name: perl-constant
+    evr: 1.33-461.el9
+    sourcerpm: perl-constant-1.33-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-debugger-1.56-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 136515
+    checksum: sha256:0b96f38c73512a61ce84171578bc9fcc5a957ff1fb267749f3af18bc7d1ce1bd
+    name: perl-debugger
+    evr: 1.56-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-deprecate-0.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14490
+    checksum: sha256:033aae2f09a7f78be08ae590f95cbce8025e5d5574cdab2bc77b554ad6e81575
+    name: perl-deprecate
+    evr: 0.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-devel-5.32.1-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 692051
+    checksum: sha256:62054544e16c34f4452dd4cf72154f0043564b2cfa2d14b082567771195724a4
+    name: perl-devel
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-diagnostics-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 215534
+    checksum: sha256:19c65175b0df9d6142bf08d6566b8f10c331735c8b95690adbc300b670a692c4
+    name: perl-diagnostics
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-doc-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 4798228
+    checksum: sha256:d9eb81a356338df906db80c853c092a1fb0de745726e82db44fb343d267b4091
+    name: perl-doc
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-encoding-3.00-462.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 65990
+    checksum: sha256:866de50f1c05940b62093f9ad35337719ddb6838011899df5fde2809eaaad23e
+    name: perl-encoding
+    evr: 4:3.00-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-encoding-warnings-0.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16539
+    checksum: sha256:897e244bb8f8800a3ed23d669df746b0bb3672cd6929b06e04e5da63b04a5aa3
+    name: perl-encoding-warnings
+    evr: 0.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-experimental-0.022-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 24376
+    checksum: sha256:ae48d202863aba2573c70d803a9931de4e3c4b0d3e4f2df561bcc1bf78dc7920
+    name: perl-experimental
+    evr: 0.022-6.el9
+    sourcerpm: perl-experimental-0.022-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-fields-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16096
+    checksum: sha256:c2f5157686257ca7b67e566b4d7e86116c6c8b9f590023adf84fde78d35d3ea9
+    name: perl-fields
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-filetest-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14556
+    checksum: sha256:4556ac1a93588b9b3e3722867ef73680028e53b3aae4af87165a1a70c79530b8
+    name: perl-filetest
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-if-0.60.800-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13876
+    checksum: sha256:ae3ce80bee55e1057ed004ec03a0e826b0cdd90ace4c0784ab2f569a2d81d40c
+    name: perl-if
+    evr: 0.60.800-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-inc-latest-0.500-20.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 27665
+    checksum: sha256:22c41d7117656dfff8d52bc8e557e6f8d11d2b5ed377173f56037a2ac8bc9139
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+    sourcerpm: perl-inc-latest-0.500-20.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-interpreter-5.32.1-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 72134
+    checksum: sha256:58aa84885d4899528fd41383bed9a35d519e4b92a2e3c924c3f75da5b9de5ba3
+    name: perl-interpreter
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-less-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13074
+    checksum: sha256:8c69534a3a191e28647b5c201dce163f2fa30f0813d54ace2345bbab830d7a9b
+    name: perl-less
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-lib-0.65-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14826
+    checksum: sha256:69c593e1972d39ab4e30e00672777165f6d5860daa8111faf781ed6d135be96c
+    name: perl-lib
+    evr: 0.65-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 137289
+    checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
+    name: perl-libnet
+    evr: 3.13-4.el9
+    sourcerpm: perl-libnet-3.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-libnetcfg-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16266
+    checksum: sha256:fcb262ee807d950b902ca12744cb2645c52de5aae0d9380a7ff4dd5574aec7fd
+    name: perl-libnetcfg
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-libs-5.32.1-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 2367250
+    checksum: sha256:b6bb9fefe4768be6034553e4f400ff08f53bad25806b91531346d4b249ad872a
+    name: perl-libs
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-local-lib-2.000024-13.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 73510
+    checksum: sha256:c8f58afb9e8eb07bc57f92c384753ee4f4fec10fa7ec7c091ad9f15110a10026
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+    sourcerpm: perl-local-lib-2.000024-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-locale-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13543
+    checksum: sha256:6b81563677505210a973fd4416f5991bf729c03f3082ac139460290643daef33
+    name: perl-locale
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-macros-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 10568
+    checksum: sha256:e499fae237cea4dcec9480576b64c69afe91c09875a8dfcf9b4daebdbeb9f197
+    name: perl-macros
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-meta-notation-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9577
+    checksum: sha256:0b7fb715954c7f67719f00bc7323d4a12453aab37acadba5106758f864c8535a
+    name: perl-meta-notation
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-mro-1.23-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 28882
+    checksum: sha256:f5cdd9299c77e94f1f9bc488bbac89a1dc2821c4ae65ca229e211719f954be24
+    name: perl-mro
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-open-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16407
+    checksum: sha256:f3e192485674a0681320f38c4163460ce0bf4855b7e825f75c371f3b3a7c778f
+    name: perl-open
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-overload-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 46157
+    checksum: sha256:f172df7417780cb61b879effe60ce6b7b4399773c46cb9896a5edf2bfba6dbda
+    name: perl-overload
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-overloading-0.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12747
+    checksum: sha256:4aae487e802df60e1e2d778b264592290ad492078877784771299561d45dfd47
+    name: perl-overloading
+    evr: 0.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 16286
+    checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
+    name: perl-parent
+    evr: 1:0.238-460.el9
+    sourcerpm: perl-parent-0.238-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-perlfaq-5.20210520-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 388755
+    checksum: sha256:e5588c37edf2bb614ffb7526deb663bc406effb86492637b4c906c5fe06f0b98
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+    sourcerpm: perl-perlfaq-5.20210520-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-ph-5.32.1-481.1.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 40942
+    checksum: sha256:18b11f3c1f581763f8713e8e7fc844c996152c5bd0fb28b04f99565e5eb9c986
+    name: perl-ph
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 121317
+    checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+    sourcerpm: perl-podlators-4.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-sigtrap-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15624
+    checksum: sha256:5b7215d5421f381137e867678492848574c2ceb58e56d47d7833d182923e92c6
+    name: perl-sigtrap
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-sort-2.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 13408
+    checksum: sha256:554155e6ff38d091ea388b1f19fc0b0950522b4c4ffe87cfee3676c4f03c046d
+    name: perl-sort
+    evr: 2.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9639
+    checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
+    name: perl-srpm-macros
+    evr: 1-41.el9
+    sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-subs-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 11525
+    checksum: sha256:0a7ef4a9a174ab981949d27a4acdc8cec87fd3513e9e607f5869851dc1c74deb
+    name: perl-subs
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-threads-2.25-460.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 62563
+    checksum: sha256:81edea43fb8fb065162f33b0e10635c60d93a08716dafdc35a06577146a1bf80
+    name: perl-threads
+    evr: 1:2.25-460.el9
+    sourcerpm: perl-threads-2.25-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-threads-shared-1.61-460.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 49523
+    checksum: sha256:ace950e794189627c3ce5850c6af33dfd9ebdabf0a2f207ddacdc7b59505f02a
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+    sourcerpm: perl-threads-shared-1.61-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-utils-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 55943
+    checksum: sha256:5c21992a23a63139c0c73ce0b9866cd9064ab2efc8d9414bb45edc6c72996162
+    name: perl-utils
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-vars-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 12885
+    checksum: sha256:5d3c58094c0158b6193d7f4ba7a4bb7ae06a78738393b31255da8b7aadb10e38
+    name: perl-vars
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-version-0.99.28-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 69418
+    checksum: sha256:1ca0091b4f21cb65b030149617ccbdb94d1f8ed929958ccd687fe2741e6b78ba
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+    sourcerpm: perl-version-0.99.28-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-vmsish-1.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14031
+    checksum: sha256:af9db38df1c1843277ebd8c6bb8d766017be043eea28246252788b055f19764d
+    name: perl-vmsish
+    evr: 1.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/policycoreutils-python-utils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 77697
+    checksum: sha256:342fa73cc94923b8ce94c4dc6ecb6f8e489b1ecfc7574ed04b93824e061c1c57
+    name: policycoreutils-python-utils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/pyproject-srpm-macros-1.16.2-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 14828
+    checksum: sha256:1bec3715412a73295a9cd2cdbc147ebee0fe23b50f4146bddc08a5761ed3928d
+    name: pyproject-srpm-macros
+    evr: 1.16.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 18705
+    checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
+    name: python-srpm-macros
+    evr: 3.9-54.el9
+    sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python-unversioned-command-3.9.25-3.el9_7.2.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 15984
+    checksum: sha256:fc54f541bf440db47821e9c5055bcff5a624abb795f697148469fac6ed150f19
+    name: python-unversioned-command
+    evr: 3.9.25-3.el9_7.2
+    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 85483
+    checksum: sha256:32b3fe1455fe3de561e13cda6b53103a54e2ff60c7df6db5da9b1c77be6c9231
+    name: python3-audit
+    evr: 3.1.5-7.el9
+    sourcerpm: audit-3.1.5-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 213334
+    checksum: sha256:43671ef28be11ed2c05803079896fd59d31ef706cad86ed5b5a0acc056f02e05
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 86091
+    checksum: sha256:a42b7400a00c4e27f762f938b7174fa3d295de5e01192ee91a37e23cc50b243b
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3-policycoreutils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 2210974
+    checksum: sha256:db891ec3a74ccdd7ab2f9cf0a4436e7df3e6702eb483cd111421f79a334e4aea
+    name: python3-policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 9344
+    checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
+    name: qt5-srpm-macros
+    evr: 5.15.9-1.el9
+    sourcerpm: qt5-5.15.9-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/r/redhat-rpm-config-210-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 72050
+    checksum: sha256:ad59b922bf8028d3021c74123d33ef770a500dc7b0dd16a34301b0fcc09c6af4
+    name: redhat-rpm-config
+    evr: 210-1.el9
+    sourcerpm: redhat-rpm-config-210-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/r/rust-1.88.0-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 26079470
+    checksum: sha256:04628295d1af436836051479fc37da860b4baf5c310c61e8cbfe7cd874150bdb
+    name: rust
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 11243
+    checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
+    name: rust-srpm-macros
+    evr: 17-4.el9
+    sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/r/rust-std-static-1.88.0-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 37564430
+    checksum: sha256:99facd93ed8575fcda613e4f4ee2317f4852ce4b3534f333b903864d5a4b9687
+    name: rust-std-static
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 45185
+    checksum: sha256:885fca6df5a4027b550b7d5267f5d7250049af8dae1b3118a798eb3b756f4cc4
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/sombok-2.4.0-16.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 56149
+    checksum: sha256:98c9f1f8c8e63206196cf50003d8f0e41144a4892909ae4c423c0a6a686d4c73
+    name: sombok
+    evr: 2.4.0-16.el9
+    sourcerpm: sombok-2.4.0-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/systemtap-sdt-devel-5.3-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 70562
+    checksum: sha256:c22b3133568aae13817d96a6ba9676afbfbc3e7012d038e5ca240b783d7b2b7a
+    name: systemtap-sdt-devel
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/s/systemtap-sdt-dtrace-5.3-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 71483
+    checksum: sha256:708659cfdbf67975253fdb314d144ac2478348fdf30b8eb8a234434fd91338bc
+    name: systemtap-sdt-dtrace
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/a/acl-2.3.1-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 79564
+    checksum: sha256:5abf618a32e0cfd20a2402b5b383e0d8055dd61c958bd1df066f5ab868358b63
+    name: acl
+    evr: 2.3.1-4.el9
+    sourcerpm: acl-2.3.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/a/alternatives-1.24-2.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 44269
+    checksum: sha256:ff47094c1f94e74225bffd2b93cd3b4690d1e20d098d35ecf2cccecd468f6f62
+    name: alternatives
+    evr: 1.24-2.el9
+    sourcerpm: chkconfig-1.24-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/a/audit-libs-3.1.5-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 140704
+    checksum: sha256:7d4c990831f2f92403ad7f59f5fadcaffef98442b951f34dd648a0b69b2b9a18
+    name: audit-libs
+    evr: 3.1.5-7.el9
+    sourcerpm: audit-3.1.5-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 8229
+    checksum: sha256:f498b0813fa1a825d550e8e3a9e42255eabfa18e6fc96adfc6cc8fa7e16dd513
+    name: basesystem
+    evr: 11-13.el9
+    sourcerpm: basesystem-11-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/bash-5.1.8-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1818376
+    checksum: sha256:4ea13d08a909851376ff25b706c942eb3b66b0205e980aa4f9176e28ee1bae37
+    name: bash
+    evr: 5.1.8-9.el9
+    sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/binutils-2.35.2-67.el9_7.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 5210492
+    checksum: sha256:b556607326220e474c8c916301728b7548481a793f6c90cdd7aead2d7a520f2d
+    name: binutils
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/binutils-gold-2.35.2-67.el9_7.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1067344
+    checksum: sha256:22e4685bcaa87ff602685ab54290defbd0efbcc4845dcc104c21a9f218d11680
+    name: binutils-gold
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/bzip2-libs-1.0.8-10.el9_5.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 47605
+    checksum: sha256:f1b07f02b34fe8d8ba24eed9afd874ced25f4da14eb1b0c804e47de1281fce49
+    name: bzip2-libs
+    evr: 1.0.8-10.el9_5
+    sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1072208
+    checksum: sha256:0554bf65d573950e7d550a07bf7d0b3def85ca3b45a7fbde4cce7cadd9a476a7
+    name: ca-certificates
+    evr: 2025.2.80_v9.0.305-91.el9
+    sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/coreutils-8.32-39.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1285039
+    checksum: sha256:a224aa371dcbbed053c88e6b25bc503042cc846e7930653bc9613525a109850f
+    name: coreutils
+    evr: 8.32-39.el9
+    sourcerpm: coreutils-8.32-39.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-39.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 2113510
+    checksum: sha256:37184551765997ac05d0e57c7398ddc8ead42df86d8352ca7b73a05c8ad91a88
+    name: coreutils-common
+    evr: 8.32-39.el9
+    sourcerpm: coreutils-8.32-39.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/cracklib-2.9.6-27.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 102420
+    checksum: sha256:be3738f99a18e14c80b771e0bcc4e13d9d067f1a1bcefd9ffcdabdb5e03bf46a
+    name: cracklib
+    evr: 2.9.6-27.el9
+    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 3821001
+    checksum: sha256:a5ae48064c709f448291de88bbf97427c65cc6a03179972496d27d4223bb6e96
+    name: cracklib-dicts
+    evr: 2.9.6-27.el9
+    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/crypto-policies-20250905-1.git377cc42.el9_7.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 92511
+    checksum: sha256:38078d704d7be136211a17da34692e9e669fd59a43ec2e82b22082e280c6f290
+    name: crypto-policies
+    evr: 20250905-1.git377cc42.el9_7
+    sourcerpm: crypto-policies-20250905-1.git377cc42.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/curl-minimal-7.76.1-35.el9_7.3.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 131803
+    checksum: sha256:cd5ac960edc3bc82b079fde27ecd3190b4cc77dd60bfce143eba5eb097f1b134
+    name: curl-minimal
+    evr: 7.76.1-35.el9_7.3
+    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/cyrus-sasl-2.1.27-22.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 78657
+    checksum: sha256:9f6bcf883d800dd0d1a6406c1b8dff4cb194cef690fb6472180af3c7dcfcf765
+    name: cyrus-sasl
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 876118
+    checksum: sha256:b0cfaae4c1a887e1c8cd58f4f4fdce366b2353094747cd21553dcb316b252699
+    name: cyrus-sasl-lib
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/d/dbus-1.12.20-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 8053
+    checksum: sha256:2fc6ba643a8f1eb9d11987ed1b9c00ecefce1f4a4de2935676c4989d0f4574d6
+    name: dbus
+    evr: 1:1.12.20-8.el9
+    sourcerpm: dbus-1.12.20-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/d/dbus-broker-28-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 192179
+    checksum: sha256:dfe710f3a07cd31fd144f439deaed0ef78b5ea65caecb754bc69959908191af7
+    name: dbus-broker
+    evr: 28-7.el9
+    sourcerpm: dbus-broker-28-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 18551
+    checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
+    name: dbus-common
+    evr: 1:1.12.20-8.el9
+    sourcerpm: dbus-1.12.20-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/d/diffutils-3.7-12.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 426776
+    checksum: sha256:1e58188524109f7f021d2a4a7b7ac5ab9ecab60dba1b1a0defc950a0f3b91f64
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/elfutils-debuginfod-client-0.193-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 47229
+    checksum: sha256:e48510717b7fb75bbe14d013a4dd63a70d600783aae1b22aa40ff92c5a513976
+    name: elfutils-debuginfod-client
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/elfutils-default-yama-scope-0.193-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 9949
+    checksum: sha256:8f64d1675627246b912a6b7b71bb4c28c2d1ef09753208253c90253a4a31132f
+    name: elfutils-default-yama-scope
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/elfutils-libelf-0.193-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 216442
+    checksum: sha256:8d58971098a0fd2ba4b0a2dfa159b663dc9ab911f07cc56cf47c4e26263ddba9
+    name: elfutils-libelf
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/elfutils-libs-0.193-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 312265
+    checksum: sha256:a2485489cd0b44e47642d5f25439967fed48498c1853b91faed171682a8d353b
+    name: elfutils-libs
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 605401
+    checksum: sha256:8c9f77d309ec86d763c537f987874088be691ddbbfea28509807030b3c2eb960
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/expat-2.5.0-5.el9_7.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 125279
+    checksum: sha256:7c349066e23424ec2a9bc8add7e7abe91b766c0afa3b7aac751227905385ad5a
+    name: expat
+    evr: 2.5.0-5.el9_7.1
+    sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/file-5.39-16.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 53426
+    checksum: sha256:cf300c3db3a9aaa9a500af67647767646ea195f69537c1cc2ae00d039f5c833d
+    name: file
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/file-libs-5.39-16.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 618014
+    checksum: sha256:6a6546cf72e0808a5e093164d63d180656b16a2874467e05c2db6d60d86ec0e4
+    name: file-libs
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/filesystem-3.16-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 5003944
+    checksum: sha256:e7d0bd8df20dfb2b499634c34ec966e1bd477a5d15f98373f56089ed0f387aca
+    name: filesystem
+    evr: 3.16-5.el9
+    sourcerpm: filesystem-3.16-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/findutils-4.8.0-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 603076
+    checksum: sha256:d4662cea7b9ae75c86e6afa1c69b3047773acf7d4a6cf8b99e63355cde0e8de8
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gawk-5.1.0-6.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1064251
+    checksum: sha256:b0cc389ad0855900c79f2cfa525df8cbc663093056b0b5d29ec3e36a189b325e
+    name: gawk
+    evr: 5.1.0-6.el9
+    sourcerpm: gawk-5.1.0-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 65838
+    checksum: sha256:18bdea48a00d647410ad82fc2cd8da81124611b1b2dd21a5526ba7e433c52be0
+    name: gdbm-libs
+    evr: 1:1.23-1.el9
+    sourcerpm: gdbm-1.23-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/glibc-2.34-231.el9_7.10.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 2885586
+    checksum: sha256:e371bfb3702c19ddb1da83593ff09e9752fb907143753efa2a3300d67c5b8fa8
+    name: glibc
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/glibc-common-2.34-231.el9_7.10.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 337047
+    checksum: sha256:7b437ae52a5f679cc799e6ac25f52e1a7b8dbdcb5e095d1f5eedc697b25560ca
+    name: glibc-common
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.34-231.el9_7.10.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1826305
+    checksum: sha256:227c1065e8c29f6035e5bf35e99559e31fa7f4d1c4a3b61ddd4d2b8e9cd4f708
+    name: glibc-gconv-extra
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/glibc-minimal-langpack-2.34-231.el9_7.10.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 28381
+    checksum: sha256:125b9a17ebe4940a79899e326ced10db04851101e1cc7899e9d0aecc8407d9fd
+    name: glibc-minimal-langpack
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gmp-6.2.0-13.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 312805
+    checksum: sha256:aeaf0f125933153cc8fc9727dac28dade4c6a8ae146812c4445643dadd3a585c
+    name: gmp
+    evr: 1:6.2.0-13.el9
+    sourcerpm: gmp-6.2.0-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gnupg2-2.3.3-5.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 2804099
+    checksum: sha256:a9650c2049dd15e6fbd731cbe8b6fa8fa3684758a14f0538ffec8c2b22df0d9a
+    name: gnupg2
+    evr: 2.3.3-5.el9_7
+    sourcerpm: gnupg2-2.3.3-5.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gnutls-3.8.3-10.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1127324
+    checksum: sha256:d53da8e98f662b5f5303cd35748a5dd807d0bb0f36f7b1d3c1da9c21c74a0ca6
+    name: gnutls
+    evr: 3.8.3-10.el9_7
+    sourcerpm: gnutls-3.8.3-10.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/grep-3.6-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 288035
+    checksum: sha256:3598703d7995b01b5b10f55ac65ce851e30f41d037e679bec4afa11a41846511
+    name: grep
+    evr: 3.6-5.el9
+    sourcerpm: grep-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/groff-base-1.22.4-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1156956
+    checksum: sha256:cde885d7a5414a62086ce1eb0edec90958fe2f53cb3f02ee08ce600c728acdee
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gzip-1.12-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 175705
+    checksum: sha256:55b983f08d8b2a0741b07f114cdba89a8ecb207064c001e90e4c76a13836d458
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/j/jansson-2.14-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 54001
+    checksum: sha256:ab715a91f15f52f07c2c5a8219b8f2074386882ad90e5131f89f78ba89e6bc4e
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/j/json-c-0.14-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 49418
+    checksum: sha256:e8d46e2dfa41daf9d8fb8928008057db9eed5ac764f68d3ef54c051a124a2ea9
+    name: json-c
+    evr: 0.14-11.el9
+    sourcerpm: json-c-0.14-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 35505
+    checksum: sha256:6e45fee51e67239d8550789a53ab7ca562c605513afe0ff890786ae9fff8fac5
+    name: keyutils-libs
+    evr: 1.6.3-1.el9
+    sourcerpm: keyutils-1.6.3-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/k/kmod-libs-28-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 71795
+    checksum: sha256:3cfa5ee7aac2933e2331e52dd4b48728f97051c6a051318c4b3ed16d10832f9c
+    name: kmod-libs
+    evr: 28-11.el9
+    sourcerpm: kmod-28-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 866052
+    checksum: sha256:9c6267e1a0f91003624557e23515f267d9044ae9f95f9f5ae5bdc75844e196f1
+    name: krb5-libs
+    evr: 1.21.1-8.el9_6
+    sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/less-590-6.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 177816
+    checksum: sha256:f909dc6be219e81adf5971c832be097d06296fabdff67688f701e3437b55d4dc
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libacl-2.3.1-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 26589
+    checksum: sha256:3612c4b0b3abab058e19ff290b96147ccbbd8179317a8d51f9ed78958d982b4a
+    name: libacl
+    evr: 2.3.1-4.el9
+    sourcerpm: acl-2.3.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libarchive-3.5.3-7.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 470532
+    checksum: sha256:ee200934415d28fba97a870e74bc8445240edb6178bb2dd9f9ae45b1342aec5a
+    name: libarchive
+    evr: 3.5.3-7.el9_7
+    sourcerpm: libarchive-3.5.3-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libassuan-2.5.5-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 75672
+    checksum: sha256:812482db276d6792f126ca46c802e30399b07335d8c847d1f3c518241ffe03c7
+    name: libassuan
+    evr: 2.5.5-3.el9
+    sourcerpm: libassuan-2.5.5-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libatomic-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 24871
+    checksum: sha256:0a1b7c663ac118a0a0f9431f75457355243edfd908d4f6340e424b9afbcfb9a7
+    name: libatomic
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libattr-2.5.1-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 21501
+    checksum: sha256:a2398158adad2016fca3d0d2c272e027b8279020992a349664caf6a2299ec50b
+    name: libattr
+    evr: 2.5.1-3.el9
+    sourcerpm: attr-2.5.1-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libblkid-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 130064
+    checksum: sha256:598ac49c65ed4a04bdbc48716be204c4a1501bc936ce1cc24d142b925b0edfb8
+    name: libblkid
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 349508
+    checksum: sha256:ff72df4a441c2f8ee8e1bcde8dcbd5bbd89250db9caf8792ff253b7af3e1c51c
+    name: libbrotli
+    evr: 1.0.9-9.el9_7
+    sourcerpm: brotli-1.0.9-9.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libcap-2.48-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 76082
+    checksum: sha256:f3df556c418c721832a8c887e81ce4bcbe15632d177fb90f8c070bd7c08d210e
+    name: libcap
+    evr: 2.48-10.el9
+    sourcerpm: libcap-2.48-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 37600
+    checksum: sha256:2483f8a4b41d76f84939855b712cfa8a990254ac36fc590daa641b2c19b014eb
+    name: libcap-ng
+    evr: 0.8.2-7.el9
+    sourcerpm: libcap-ng-0.8.2-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libcbor-0.7.0-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 62130
+    checksum: sha256:c18f6560c02f3692d8fea54dc89548d4fd183cb7f73ef3ef7e0cf2f7d1815a47
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 27218
+    checksum: sha256:e42731a8cd63ee553dd01bf989e6cdda8d33fb515119d83039046c987a000f6c
+    name: libcom_err
+    evr: 1.46.5-8.el9
+    sourcerpm: e2fsprogs-1.46.5-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libcurl-7.76.1-35.el9_7.3.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 321185
+    checksum: sha256:4fe25624bf8d64e84154fbb95d64567dc6d50d841ebf41d78fdc3445b84f25b6
+    name: libcurl
+    evr: 7.76.1-35.el9_7.3
+    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 837087
+    checksum: sha256:3c73512cfb5cff3477193e37e80fbd416449035f909998b7873bcade57aa242c
+    name: libdb
+    evr: 5.3.28-57.el9_6
+    sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libeconf-0.4.1-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 32878
+    checksum: sha256:a3fbb9481c4d4f13cc1f1593a83f31fc27975b759fd01235b875d09973eeb102
+    name: libeconf
+    evr: 0.4.1-4.el9
+    sourcerpm: libeconf-0.4.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 121673
+    checksum: sha256:ce0039b9b7d363df74541da164ebccde85a40f083f5b55382325db6584bc693c
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 287857
+    checksum: sha256:bc6eb253e6cf0e06fa7270c029502e14ee70cb22c2ed86b15f2a9952ba2f375f
+    name: libevent
+    evr: 2.1.12-8.el9_4
+    sourcerpm: libevent-2.1.12-8.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libfdisk-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 176639
+    checksum: sha256:4c772f1872f91203182ffec334b60d8c11a1d5dcca283e203af0a564cbab9458
+    name: libfdisk
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libffi-3.4.2-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 40799
+    checksum: sha256:c5042688cccb346b2bb0865410564d305a9b86e7618558354428ebc09ff689d8
+    name: libffi
+    evr: 3.4.2-8.el9
+    sourcerpm: libffi-3.4.2-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libfido2-1.13.0-2.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 112104
+    checksum: sha256:9899776f2483012e06cad4d7a298b59b2a0ddf1d3226012db7559f00178c81d2
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libgcc-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 75746
+    checksum: sha256:91ea5d90409c19d054ca5f3d599c43a874f93231e8157d223f2b685867b7e06f
+    name: libgcc
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 612983
+    checksum: sha256:917a9fc0eca0405813697b4d830578c92b01c1dba766321bfa880a248b0c4d5e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libgomp-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 275517
+    checksum: sha256:8941f8174001217f9edaad648fa68288477e017268653a077bfb31e104bd5f9c
+    name: libgomp
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libgpg-error-1.42-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 234885
+    checksum: sha256:2db222784b8d4183fd2704cffa9df4d7023ebd5dc51806fbdc30e8fa9123c5a5
+    name: libgpg-error
+    evr: 1.42-5.el9
+    sourcerpm: libgpg-error-1.42-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libidn2-2.3.0-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 110270
+    checksum: sha256:28a3da7752093735a9c0de6232bcb6c3d9910a90956891396712825b354bf7d5
+    name: libidn2
+    evr: 2.3.0-7.el9
+    sourcerpm: libidn2-2.3.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libksba-1.5.1-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 177249
+    checksum: sha256:7811870bfcc1665daaae2f088e737bc7d0c49a753c1db1cf5a4d9c2162f29cc9
+    name: libksba
+    evr: 1.5.1-7.el9
+    sourcerpm: libksba-1.5.1-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libmount-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 159458
+    checksum: sha256:c92c1ad53728ceb535bee3bbf0d1296abc5e446aaac1d17a14cc701ceb93e281
+    name: libmount
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_7.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 89545
+    checksum: sha256:9d85c546efc693de263ef885d1bd79d00717a8a64dfeb7c7baa967401f757160
+    name: libnghttp2
+    evr: 1.43.0-6.el9_7.1
+    sourcerpm: nghttp2-1.43.0-6.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 55331
+    checksum: sha256:f7ad9deafd994d2485e05ed54d05030a28c2c7e544e94e8d7cc9287c4e9b8c10
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 42712
+    checksum: sha256:a96600fec79e7d94523816dc620203e812c4a08c82c07fb3bb62d7e9e6e1f661
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libpsl-0.21.1-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 69346
+    checksum: sha256:dfdaff3aa507721d913aae308caa7b672a952e1d21485958daa749b2d1793fc3
+    name: libpsl
+    evr: 0.21.1-5.el9
+    sourcerpm: libpsl-0.21.1-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 128350
+    checksum: sha256:0b13ff548b9b0be9f8d0271d90fa3673c081fbc22dc869ae4c37c68fa2a32c09
+    name: libpwquality
+    evr: 1.4.4-8.el9
+    sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/librtas-2.0.6-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 86335
+    checksum: sha256:64d105e7f8b9ee542efe65816ae77fb38988c00bef1e0cc5ea3e1a4e89fb7505
+    name: librtas
+    evr: 2.0.6-1.el9
+    sourcerpm: librtas-2.0.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 84378
+    checksum: sha256:ef769ff2877361cbce88aac5e35091e9798c7cc23f91f12637b1a4229e056ea6
+    name: libseccomp
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libselinux-3.6-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 102114
+    checksum: sha256:ca29ae2f3e2ed004aafca74bd18a97b5e987688bac061f573a9ad9903d2ce23a
+    name: libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 203090
+    checksum: sha256:e7817e5ab1c6a69683cc020e8e27770eaf8f67b5206726d1a20bfc2fa8bb6b1e
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 136617
+    checksum: sha256:fb48b9d444876b4517d441b63955b32ff022b27d99865384900912c55d84f808
+    name: libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libsepol-3.6-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 375249
+    checksum: sha256:97e9b7c8e631f7c9e2ee2968f797302d854c0e7b15b5ea46675bdebc19bd5609
+    name: libsepol
+    evr: 3.6-3.el9
+    sourcerpm: libsepol-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libsigsegv-2.13-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 31522
+    checksum: sha256:9e67d1dd24a8ffa2366479c3c15691b530786ccee77e7c93090c192cce1e63b3
+    name: libsigsegv
+    evr: 2.13-4.el9
+    sourcerpm: libsigsegv-2.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libsmartcols-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 73994
+    checksum: sha256:85729feb0f651f49aef6a3ab41218de9ecf3d97e4edfeb905667c9554d6f6716
+    name: libsmartcols
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libssh-0.10.4-17.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 243596
+    checksum: sha256:cf9bcbd36e0d333f87fca58187a49ac3b179f31025437acaa97ff4fac61fe902
+    name: libssh
+    evr: 0.10.4-17.el9_7
+    sourcerpm: libssh-0.10.4-17.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libssh-config-0.10.4-17.el9_7.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 8268
+    checksum: sha256:9815db066478c3b1bdd5367de09e0aedf465127716358a8877990736589c6078
+    name: libssh-config
+    evr: 0.10.4-17.el9_7
+    sourcerpm: libssh-0.10.4-17.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libstdc++-11.5.0-11.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 856898
+    checksum: sha256:24c5b7dc54991dafb35fc61ea07f4b5d4ea59b6d88d7eabf301d87cd7e904305
+    name: libstdc++
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 84469
+    checksum: sha256:05d77fc16cb5888d298a1d57d419da59894e60eed3220f674f74d50337db167f
+    name: libtasn1
+    evr: 4.16.0-9.el9
+    sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libunistring-0.9.10-15.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 519115
+    checksum: sha256:8ea5a350f1a29e412100e7b51967f440715f1cf8480a2ccae1a703806953486e
+    name: libunistring
+    evr: 0.9.10-15.el9
+    sourcerpm: libunistring-0.9.10-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libutempter-1.2.1-6.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 30656
+    checksum: sha256:b62a3c29e31482fc21de315eaefa28f3e52f59396b0a33e6d1267822cabc1c67
+    name: libutempter
+    evr: 1.2.1-6.el9
+    sourcerpm: libutempter-1.2.1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libuuid-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 34226
+    checksum: sha256:164d9da68feaa8bc4cd4edacbe93e6727a78a4a6398b62444ac87c643325fb77
+    name: libuuid
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libverto-0.3.2-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 25896
+    checksum: sha256:54ba79ab0122e9e427efa5b10e9c63dbb28e13c4698711fd5c5bde4e9d794a65
+    name: libverto
+    evr: 0.3.2-3.el9
+    sourcerpm: libverto-0.3.2-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 136063
+    checksum: sha256:c0bc93eea8ae33a88c33d7f4ac290a7c4fb844e591fb69a55e50dca8df8fbbff
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libxml2-2.9.13-14.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 842812
+    checksum: sha256:a946303620df2a718355c4ffcbcfd5bbf95d606a3458b806b8586343f7b31121
+    name: libxml2
+    evr: 2.9.13-14.el9_7
+    sourcerpm: libxml2-2.9.13-14.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libzstd-1.5.5-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 329280
+    checksum: sha256:c613b79b53a7d9b00bb33fac7971d412d8f9f9656436cdc8e451e4a805f53ee8
+    name: libzstd
+    evr: 1.5.5-1.el9
+    sourcerpm: zstd-1.5.5-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 152736
+    checksum: sha256:5c301c0b57c154457144d7857dcedd4f37025129a9fe868a1c76c9b0461e8e07
+    name: lua-libs
+    evr: 5.4.4-4.el9
+    sourcerpm: lua-5.4.4-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 90452
+    checksum: sha256:2a7ef3bd2571c62bf75f3bc1a9206f5715ddcb1cb77f561689de458a417e5914
+    name: lz4-libs
+    evr: 1.9.3-5.el9
+    sourcerpm: lz4-1.9.3-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/make-4.3-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 567121
+    checksum: sha256:6c3f559c10b0bfdeb892314c26622f06999b202f57d881444cc4361ec7dad88c
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/man-db-2.9.3-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1271757
+    checksum: sha256:41c3d495fff77830c22b429be9cb4cf36b3995914113228084deb3bda5e38639
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/mpfr-4.1.0-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 331631
+    checksum: sha256:2b26e39f0eb248620c4ad20dff1690502c1912374b8ca7158d6d7eab33c27209
+    name: mpfr
+    evr: 4.1.0-7.el9
+    sourcerpm: mpfr-4.1.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/n/ncurses-6.2-12.20210508.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 422717
+    checksum: sha256:c78f7f10910ef8184813cfd5e6fd1698a45c78a75d42ddf3a51b8941b6ea2847
+    name: ncurses
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 97840
+    checksum: sha256:d62dfd41f9688efa2cf1ceedb96084c63e297fbdcfd1e72bc6757c730092b60c
+    name: ncurses-base
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 379141
+    checksum: sha256:f18294157d19ce7c86c07483b5c1262be4c899dd63b4297e4af15c63b91fd9cf
+    name: ncurses-libs
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/n/nettle-3.10.1-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 592348
+    checksum: sha256:c3901a9b78debab9287b1f884124d3f897b461faa385fe37c1e8aafdb54ea4b6
+    name: nettle
+    evr: 3.10.1-1.el9
+    sourcerpm: nettle-3.10.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/n/npth-1.6-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 27410
+    checksum: sha256:55296dd542e3e8fb28635157bfe643ae29afa06f5b3a55e48ff5edf6ceedd3c9
+    name: npth
+    evr: 1.6-8.el9
+    sourcerpm: npth-1.6-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openldap-2.6.8-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 329998
+    checksum: sha256:8476e903e6a0ba08961f26a776bd5ae130771ce83edcbc9c57260a49e654c053
+    name: openldap
+    evr: 2.6.8-4.el9
+    sourcerpm: openldap-2.6.8-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssh-8.7p1-48.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 487512
+    checksum: sha256:94bcd7a39cce25a18345ccb091bc2f7f217d1db65ecd560568990709da543eb1
+    name: openssh
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssh-clients-8.7p1-48.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 761928
+    checksum: sha256:16edef0f3ba6f6ca005e0dcceeee31f6df4ed3871e2da119fa4c64ae8588ef0d
+    name: openssh-clients
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-3.5.1-7.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1566615
+    checksum: sha256:c5a5284070d6d182a4c93283039a327bf02efd41ab7ab4a748971421773ba605
+    name: openssl
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-fips-provider-3.0.7-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 9390
+    checksum: sha256:c4a55a68f123fd873380d919ede200fb64f7443eb4235ce555a307cfee9fb6a5
+    name: openssl-fips-provider
+    evr: 3.0.7-8.el9
+    sourcerpm: openssl-fips-provider-3.0.7-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 576788
+    checksum: sha256:325a2017d21f5ca789931de321cd9fb5f359ce12fb0d0acc2f3cd9dc00b00dc3
+    name: openssl-fips-provider-so
+    evr: 3.0.7-8.el9
+    sourcerpm: openssl-fips-provider-3.0.7-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-libs-3.5.1-7.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 2550625
+    checksum: sha256:99dac7eb92b2cf3e4e2f512378397f59d206795e89bef3bb6891062e334fa65c
+    name: openssl-libs
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 547598
+    checksum: sha256:fd4240aac85927fc57c6cc5bc689149b3bf1b92b676064bfb23a6107a343310c
+    name: p11-kit
+    evr: 0.25.3-3.el9_5
+    sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/p11-kit-trust-0.25.3-3.el9_5.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 161121
+    checksum: sha256:b42303b7d5d10b6303e8abaccbaa302df0bca5fdd9949e043aaf1c5b2a53254d
+    name: p11-kit-trust
+    evr: 0.25.3-3.el9_5
+    sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pam-1.5.1-26.el9_6.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 677447
+    checksum: sha256:93eb19dd21e5bb33d1d004c9e49e49d0049aca990074b8c6f4204e5af4c3c38e
+    name: pam
+    evr: 1.5.1-26.el9_6
+    sourcerpm: pam-1.5.1-26.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pcre-8.44-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 208333
+    checksum: sha256:a9194f82f80f11599236c3acd4cd6faf0a4fd4aec302f44365847e6222499e65
+    name: pcre
+    evr: 8.44-4.el9
+    sourcerpm: pcre-8.44-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pcre2-10.40-6.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 243057
+    checksum: sha256:fcccf3d6981333ac0ac747ee143dae975381e02025ad2bc53e6aa7e0dc5fafb7
+    name: pcre2
+    evr: 10.40-6.el9
+    sourcerpm: pcre2-10.40-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 147926
+    checksum: sha256:d386b5e9b3a4b077b2ba143882e605750855dd3354f13c55fa12ed26908cb442
+    name: pcre2-syntax
+    evr: 10.40-6.el9
+    sourcerpm: pcre2-10.40-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 46315
+    checksum: sha256:a70516a3a8f016a80613bc071586cd653db12a650c4c9f057743125cb7ad7433
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 12416
+    checksum: sha256:1d641be62db76b074f4ca2d6b470d85dcf806d96e2c834337482a73984db1979
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/policycoreutils-3.6-3.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 246196
+    checksum: sha256:2c5404e64f1662872b1a65d6e4b19928840769afb51d68aeb68c9d74ee2ff3eb
+    name: policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/popt-1.18-8.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 74761
+    checksum: sha256:f306d3dc7ae527041162c2f44e153dcd00826c8f79ef588437883c34abe12d9d
+    name: popt
+    evr: 1.18-8.el9
+    sourcerpm: popt-1.18-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 378421
+    checksum: sha256:d76d17ceec32bdf37c72a8ff52582b202fff7b7a3514dc2102ce3fcb42ff1382
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 60882
+    checksum: sha256:e6ec3390a736b085f403168c512a6b2b6f8e12a8fd5a4459f1c7dbbff2b67c33
+    name: publicsuffix-list-dafsa
+    evr: 20210518-3.el9
+    sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-3.9.25-3.el9_7.2.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 33409
+    checksum: sha256:f49cb9a5fe7593f0191fc2b9d3c6a4484190805f4f546af78de386a952a859ee
+    name: python3
+    evr: 3.9.25-3.el9_7.2
+    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-libs-3.9.25-3.el9_7.2.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 8449403
+    checksum: sha256:6160361ca480d14ea505f6afd71f83ba1a9bb6fbd2a1a91b07ce0f377e80b0c8
+    name: python3-libs
+    evr: 3.9.25-3.el9_7.2
+    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1193706
+    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    name: python3-pip-wheel
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 157800
+    checksum: sha256:4c7b1bbabe7f37d1dd098c9d893f7f8e97e5fd43aa8fa4d4c58a3b6b66e69c70
+    name: python3-pyparsing
+    evr: 2.4.7-9.el9
+    sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 630876
+    checksum: sha256:9285d12c8af13fa320d0a9d18798859158c64480dd2aa000a58632bcd27cf13b
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-setuptools-53.0.0-15.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 958725
+    checksum: sha256:e3c5b5927ad0c0bde27a95c54f7a1295965b317d225ece2e98acd365aa45d09f
+    name: python3-setuptools
+    evr: 53.0.0-15.el9
+    sourcerpm: python-setuptools-53.0.0-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 479203
+    checksum: sha256:36dacb345e21bc0308ef2508f0c93995520a15ef0b56aab3593186c8dc9c0c5a
+    name: python3-setuptools-wheel
+    evr: 53.0.0-15.el9
+    sourcerpm: python-setuptools-53.0.0-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/readline-8.1-4.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 236301
+    checksum: sha256:e346c16a0e4b617897f744fe448701cdc90202aecc61d5a40b9ed0986609cb25
+    name: readline
+    evr: 8.1-4.el9
+    sourcerpm: readline-8.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/redhat-release-9.7-0.7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 54168
+    checksum: sha256:d980bbb2550eb9921ac56fee1359ec07961ca6d177ec6e865c4aa466f2fa565d
+    name: redhat-release
+    evr: 9.7-0.7.el9
+    sourcerpm: redhat-release-9.7-0.7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/rpm-4.16.1.3-39.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 546629
+    checksum: sha256:2f55ea9c1fa47d8b45f61d231aebfebb2e8c399e3edfa1b20d2fe1b20b8c74a0
+    name: rpm
+    evr: 4.16.1.3-39.el9
+    sourcerpm: rpm-4.16.1.3-39.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/rpm-libs-4.16.1.3-39.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 359163
+    checksum: sha256:e94030abfe242b8e8b35292754f0505e3f195ec03fe46d2e19ce8a0825e0afb6
+    name: rpm-libs
+    evr: 4.16.1.3-39.el9
+    sourcerpm: rpm-4.16.1.3-39.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/sed-4.8-9.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 322393
+    checksum: sha256:afa65fcc13e68755b67a318737603ed72f9569669c51b858f3c04e99a9272c89
+    name: sed
+    evr: 4.8-9.el9
+    sourcerpm: sed-4.8-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 153791
+    checksum: sha256:0891d395ce067121c28932534237ad1ce231f2bfa987411ad62e73a12d11eb6a
+    name: setup
+    evr: 2.13.7-10.el9
+    sourcerpm: setup-2.13.7-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/shadow-utils-4.9-15.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1272062
+    checksum: sha256:306514b0e1eff64bbcf43b53cd73f952e48cd4221c3d215dfe7b1908354f07ca
+    name: shadow-utils
+    evr: 2:4.9-15.el9
+    sourcerpm: shadow-utils-4.9-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-9.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 748982
+    checksum: sha256:f1f8905dd84e19aed6c4a91654006f52387c233662afb719a46b223e806354a1
+    name: sqlite-libs
+    evr: 3.34.1-9.el9_7
+    sourcerpm: sqlite-3.34.1-9.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-252-55.el9_7.8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 4429959
+    checksum: sha256:cd0eddb43f73a2b75c059aae679e400c1c906be503dd989ee2ec415b82db7366
+    name: systemd
+    evr: 252-55.el9_7.8
+    sourcerpm: systemd-252-55.el9_7.8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-libs-252-55.el9_7.8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 710620
+    checksum: sha256:ce27f22f72b9bc45bb09924bdd51a3a99a63fbdc88bbd3f22c6ecd70affded1c
+    name: systemd-libs
+    evr: 252-55.el9_7.8
+    sourcerpm: systemd-252-55.el9_7.8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 291947
+    checksum: sha256:3ff940b11e05c11b1be415c6e5444bf365ab5516dde717ef5f49c32ebbdf4ed6
+    name: systemd-pam
+    evr: 252-55.el9_7.8
+    sourcerpm: systemd-252-55.el9_7.8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 57061
+    checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
+    name: systemd-rpm-macros
+    evr: 252-55.el9_7.8
+    sourcerpm: systemd-252-55.el9_7.8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tcl-8.6.10-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 1250450
+    checksum: sha256:fd507cecffee907324ae0f0636112b8de5064f09c1468a9b571fe231a4f6c49a
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tzdata-2026a-1.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 933237
+    checksum: sha256:90bc7252dcef87507a6dc097763894d264544b42c77ce67696192db2bcc8cd07
+    name: tzdata
+    evr: 2026a-1.el9
+    sourcerpm: tzdata-2026a-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/u/unzip-6.0-59.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 190400
+    checksum: sha256:08da7102308f1ad028360ccdf78d0de9c3ff16c9cdb2aab71d7182f600f933be
+    name: unzip
+    evr: 6.0-59.el9
+    sourcerpm: unzip-6.0-59.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/u/util-linux-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 2424397
+    checksum: sha256:f8fb64127696c7c7856fddc98e9b6642b2d603487363eda8d72f449e7efe39c9
+    name: util-linux
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9_7.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 495317
+    checksum: sha256:d9a5aee7efe2b85b531648bd8d0aa53a0e02d2dbe2f77881b7072ac9390eeb2c
+    name: util-linux-core
+    evr: 2.37.4-21.el9_7
+    sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-23.el9_7.2.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 20860
+    checksum: sha256:e3fc2d706b1e395043a8a9bc76bb04c1ef7174269c840cb73176d00260df2724
+    name: vim-filesystem
+    evr: 2:8.2.2637-23.el9_7.2
+    sourcerpm: vim-8.2.2637-23.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 120233
+    checksum: sha256:4e67d1701dc3e5f23191fcbc72e01d48e3287dc32046db9514eb19b902dfc089
+    name: xz-libs
+    evr: 5.2.5-8.el9_0
+    sourcerpm: xz-5.2.5-8.el9_0.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/z/zip-3.0-35.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 282944
+    checksum: sha256:9af29cefba99330a06abd6ace7eb1f3ea77d1b2d50a2cd6d4e3fade1e603f26f
+    name: zip
+    evr: 3.0-35.el9
+    sourcerpm: zip-3.0-35.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/z/zlib-1.2.11-40.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 106130
+    checksum: sha256:330a6c1a9e15d4118a4dbff5b5446f054e42a8286fbd85a416b8d30771d6db6f
+    name: zlib
+    evr: 1.2.11-40.el9
+    sourcerpm: zlib-1.2.11-40.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: s390x
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/a/annobin-12.98-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 1116289
+    checksum: sha256:95cd234971246abc4ac5db520dfe978ed1ce4ca34260c7fa3e87c4a0dc9614df
+    name: annobin
+    evr: 12.98-1.el9
+    sourcerpm: annobin-12.98-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cargo-1.88.0-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 8685549
+    checksum: sha256:77bc5c4dedf9cce8a572ece13c36d28447efe294fae2c4befee87c6998da9808
+    name: cargo
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/checkpolicy-3.6-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 351280
+    checksum: sha256:f2637770a250890cc2f6168a6457d92b6cefe53a8c5699e3b789fda6020d0311
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/clang-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 159239
+    checksum: sha256:350b5f3c2951e882b89b396ddd04d7e564d697d291289a8a2c999adc878deec0
+    name: clang
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/clang-libs-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32258947
+    checksum: sha256:50028279b2bb57febe3dec36a7792b2e055c755fda8da5a79f5bf9fe93ccc757
+    name: clang-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/clang-resource-filesystem-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14976
+    checksum: sha256:382f63ddd3198af35a4eb3c38475f29722e71f4daa5a9dec56b81e1be090a1cd
+    name: clang-resource-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cmake-3.26.5-3.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 7269200
+    checksum: sha256:17ab2c7fcc6d1c0d4190190e2f48910c09d88d7642ac9fdae07120eb5f6a4b9b
+    name: cmake
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cmake-data-3.26.5-3.el9_7.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 2483069
+    checksum: sha256:6b8afdf96d315c36df391e0f170d5ba845d11704549c4ffa3533aa43922d722e
+    name: cmake-data
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cmake-filesystem-3.26.5-3.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18571
+    checksum: sha256:5e313cf033574b1433bddfdb8112e6d9c8eff7a0c61cd4b2f9c0b82729c5712e
+    name: cmake-filesystem
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/compiler-rt-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 1735916
+    checksum: sha256:bdcd2d19c645f2be7da1bd33a27269a48979c95ff1a860b5cabda601e2efeae2
+    name: compiler-rt
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cpp-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 8605538
+    checksum: sha256:3d378bca60079d3c3b91be5fcbe691045b6d330ede4a9d587add926023923b76
+    name: cpp
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cyrus-sasl-devel-2.1.27-22.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 113185
+    checksum: sha256:515e83002ecb1936dfcd8af42e4be7b269e599898535eb23719784ee35232fbb
+    name: cyrus-sasl-devel
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/d/dwz-0.16-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 135160
+    checksum: sha256:762c07536f382d3828880ae8b9ddec04945ebea74aa86b9e74e741dd9defac4e
+    name: dwz
+    evr: 0.16-1.el9
+    sourcerpm: dwz-0.16-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/e/efi-srpm-macros-6-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21527
+    checksum: sha256:4cf4841f5c7145f3dce72175e09d39b02c7fbb44be552d9d407431a7a81ef9ef
+    name: efi-srpm-macros
+    evr: 6-4.el9
+    sourcerpm: efi-rpm-macros-6-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 30140
+    checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
+    name: fonts-srpm-macros
+    evr: 1:2.0.5-7.el9.1
+    sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 26832702
+    checksum: sha256:1736fec0a8098efc13cdc21e9a5f74747a320873247175cf95ce7e37c427e9f2
+    name: gcc
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-c++-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 10696287
+    checksum: sha256:b68a0916f240665b5fa3ae456bd8517823cfe435e3fcc6d5919924c3d5083b75
+    name: gcc-c++
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 35933
+    checksum: sha256:ea51e47aee04ad86c680b9dc817fd79d1f44d77de4309c692b07fd1c1b3ce267
+    name: gcc-plugin-annobin
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-5.el9_7.1.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 6561866
+    checksum: sha256:acac53ed31953114f71300fc6245b461198507fe71f8aabedb0f3fdea454bc6c
+    name: gcc-toolset-14-binutils
+    evr: 2.41-5.el9_7.1
+    sourcerpm: gcc-toolset-14-binutils-2.41-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-12.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 39518668
+    checksum: sha256:279cc6e122ea33a1b0af0ee9b44a51940844c64fb16e73d6c0433ffdf9b8d7e0
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-12.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12642557
+    checksum: sha256:fe44e4beaa2a1db383a7a30114c4c23728d1b12781b159252b9cfcb898288694
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-12.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 3920272
+    checksum: sha256:71ed987bf5a6603371d773bcd30bad4d1d23539f49f1139e8e5bb62d0238d666
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 58544
+    checksum: sha256:22ace86885624516e26566042ebc8b534d2caeafef571f0a1580925f6f167e9f
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9252
+    checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+    sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-2.47.3-1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 51862
+    checksum: sha256:2dc870f585b2677efba54ef8544339e810cba1769accd8bd4d1e777325773efc
+    name: git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 4802290
+    checksum: sha256:82a357dd414ce958dd199566e6ccff6593a7817c5c70a2f268d38459004afff9
+    name: git-core
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 3195826
+    checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
+    name: git-core-doc
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/glibc-devel-2.34-231.el9_7.10.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 55293
+    checksum: sha256:04f840e95240908817b24e8e14471469fe4acdc36e21cf1f4bf3f93df5916f1b
+    name: glibc-devel
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/glibc-headers-2.34-231.el9_7.10.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 555359
+    checksum: sha256:8a0515facc94836c5695c9cf671d166594ff3369bc07def5425972f22ef75fcf
+    name: glibc-headers
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_7.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 33806
+    checksum: sha256:ea2a392fd650fc6c4928590af98a4b35f705537b0353417599ba97c21b271404
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_7
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 3017165
+    checksum: sha256:bccf67fd38fb285adc59ba6a0f0427553e39b917b699258cb8a7da8c7ca2a6dd
+    name: kernel-headers
+    evr: 5.14.0-611.47.1.el9_7
+    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14098
+    checksum: sha256:54edccc470e78f835a572f809b11413bb62bc5ca765e523eaf17ca23cdde08d3
+    name: kernel-srpm-macros
+    evr: 1.0-14.el9
+    sourcerpm: kernel-srpm-macros-1.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libasan-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 412655
+    checksum: sha256:1189c63ffc7467e57aab53abb88b5426780271485b47ef4c2eabefae921180f5
+    name: libasan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libdatrie-0.2.13-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 34848
+    checksum: sha256:835b33519221e93872d8cd4f2a3b7c5b58d84ae616ef77c87791b5e16e8a9759
+    name: libdatrie
+    evr: 0.2.13-4.el9
+    sourcerpm: libdatrie-0.2.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libmpc-1.2.1-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 66959
+    checksum: sha256:5d57ddf803a764bbbf229ccb71c8b4fbeed604b39858174d8ffee1b24510cc8c
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libstdc++-devel-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 2511189
+    checksum: sha256:3881c5c9275a6a0bc9f6bf62c56722e2c9190be6a06ee08ee14b743d888ff9d3
+    name: libstdc++-devel
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libthai-0.1.28-8.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 217030
+    checksum: sha256:c788fe7b1d4392c6c89795ba77285922c6462f8a6ce7c4ace94858b6b0d1d76b
+    name: libthai
+    evr: 0.1.28-8.el9
+    sourcerpm: libthai-0.1.28-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libubsan-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 177964
+    checksum: sha256:e851008460b707db3cc34993492d032c0821911b95529e1d65119ce001a96b37
+    name: libubsan
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 150561
+    checksum: sha256:7badf8ffee70ff4eabd9b96701d8926752c961e395dd79ecd70460056b88024f
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 33073
+    checksum: sha256:b3f6b6b72b5c96a8527e6dd46c421066f94d48f0ada76bbc638bf89f81b19360
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/llvm-filesystem-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9350
+    checksum: sha256:b3f17a1e4c4134d44019fdf4212ee955f1fd0bf8130f5e286741551309664a16
+    name: llvm-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/llvm-libs-20.1.8-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32972723
+    checksum: sha256:9316becb4c4b22d061a94f46c66fe0fa9754bc3c791c9e3e8ed6286f4333111c
+    name: llvm-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 10476
+    checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
+    name: lua-srpm-macros
+    evr: 1-6.el9
+    sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9270
+    checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+    sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 8807
+    checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+    sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/o/openssl-devel-3.5.1-7.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 4997670
+    checksum: sha256:c8d3dd29b240b782a39624632849a1401d4dc74b42e79e435e841cf22d65e853
+    name: openssl-devel
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-5.32.1-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 8409
+    checksum: sha256:0eb21bda10ed168bfc32ed9bb6543244a3def130a1bc7008317fbf5081ed076f
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 52041
+    checksum: sha256:3d252e247a41978a10faef66931ac5fb2525c7fa708d8caa537d368ef5ba62ce
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+    sourcerpm: perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Archive-Tar-2.38-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 77744
+    checksum: sha256:5cf97230d350543cdf34f379dc04e1383f89591ad76768b5a2738b474cdec404
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+    sourcerpm: perl-Archive-Tar-2.38-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Archive-Zip-1.68-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 118766
+    checksum: sha256:2237a7cdfa30cda2ad475cb6ee5796f1e4cafa07e8760e08bca8d252cd6eb51d
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+    sourcerpm: perl-Archive-Zip-1.68-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Attribute-Handlers-1.01-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 27731
+    checksum: sha256:95ee8b22f5c962b56b95dc3e74280ed1471c17bb2031995d3efd431478e40aac
+    name: perl-Attribute-Handlers
+    evr: 1.01-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21344
+    checksum: sha256:b4557d853be8048aaefde5c4083c43fa34375e224731e93e584e4e3d5db46ac3
+    name: perl-AutoLoader
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-AutoSplit-5.74-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21714
+    checksum: sha256:de53b7057da078864d27f4acddf37594d40ee4d5f710d129c40cfb5c6097ceb0
+    name: perl-AutoSplit
+    evr: 5.74-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-B-1.80-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 182957
+    checksum: sha256:72091245e56f0988d5ce12cff6529606e05a918a8b844c0bf4c5e00f12db6438
+    name: perl-B
+    evr: 1.80-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Benchmark-1.23-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 27055
+    checksum: sha256:690cc6ca69fd267f025ddc18116d8f10dff6693645ff949820c83ed7776aa454
+    name: perl-Benchmark
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-CPAN-2.29-5.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 589480
+    checksum: sha256:a46e7bb747f0b5dc26d8eda788b98492576048f5df271d070c35118f8d980b9d
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+    sourcerpm: perl-CPAN-2.29-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 17060
+    checksum: sha256:35687783ded44b01c37af59f66499b42e10df074c36608fc3f84bd4ae082c852
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+    sourcerpm: perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-CPAN-Meta-2.150010-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 210745
+    checksum: sha256:ec35026baabe720d7c880f896f84271f0c408c56d3fea6d7c5d22580ac175690
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+    sourcerpm: perl-CPAN-Meta-2.150010-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 35205
+    checksum: sha256:eca17976f76fd8d31eda995a9ced2d813c1c94b9efafa1a83454fb120be62784
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+    sourcerpm: perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 29542
+    checksum: sha256:b21eb298e56bc6623257cae1434198789e80ab92b818af4e29514a7bbc6f5910
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+    sourcerpm: perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32039
+    checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
+    name: perl-Carp
+    evr: 1.50-460.el9
+    sourcerpm: perl-Carp-1.50-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Class-Struct-0.66-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22220
+    checksum: sha256:d35ff343bd718fbd8531995a8aedb866c6d37fac6a688fcf9a458017781bf058
+    name: perl-Class-Struct
+    evr: 0.66-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Compress-Bzip2-2.28-5.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 73613
+    checksum: sha256:63561c2a32e5b8db57310f28f0ecacd0d6313dd39e482d3c2d0068aad49705b2
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+    sourcerpm: perl-Compress-Bzip2-2.28-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 38220
+    checksum: sha256:724d43294e7b778d326b427592dc135536106acbe37c51c152a1e92418006be7
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 54099
+    checksum: sha256:03c2232e65e3f6b72b5c093ec6c4174fdf32016aa6db8295794a91bba0477acc
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+    sourcerpm: perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 64620
+    checksum: sha256:78b518257c483956118cbccb1d6cc3410b436317152e8a14e2f5289029ca58ea
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+    sourcerpm: perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Config-Extensions-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12128
+    checksum: sha256:86695c36cd0bd3516cdb72d9f30ddec6aef47eb48432a76b71d15372e86549a6
+    name: perl-Config-Extensions
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Config-Perl-V-0.33-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 24943
+    checksum: sha256:7ec321ecb6f37b6be09ad182cb66fdeee9f12138f75fc48858bde2177c358d1d
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+    sourcerpm: perl-Config-Perl-V-0.33-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-DBM_Filter-0.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32009
+    checksum: sha256:2ea4092322228a400fe8ad6c19302878e46771cbc1a2d623371c49732ad5e018
+    name: perl-DBM_Filter
+    evr: 0.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-DB_File-1.855-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 84019
+    checksum: sha256:bbf9e756b7fa6fca35ba34875341c84a967fc00de39fa6516586f8fe8bb9f27c
+    name: perl-DB_File
+    evr: 1.855-4.el9
+    sourcerpm: perl-DB_File-1.855-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 58967
+    checksum: sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+    sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Data-OptList-0.110-17.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 30694
+    checksum: sha256:1455a3e90116f504008f8d27db57acb65c3389440dc6e2d605f54bf40b009a10
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+    sourcerpm: perl-Data-OptList-0.110-17.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Data-Section-0.200007-14.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 28030
+    checksum: sha256:9fb57b4fbcfea93de114505082261abd97f576cf78e1a205c255d69d8eb6babf
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+    sourcerpm: perl-Data-Section-0.200007-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Devel-PPPort-3.62-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 218818
+    checksum: sha256:21b91196e9b6f052db4bea8839b4a64801a931eb1f4df44c66acda557a3edc09
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+    sourcerpm: perl-Devel-PPPort-3.62-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Devel-Peek-1.28-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 31975
+    checksum: sha256:f60d62d30ed09b58fd0228c5c3bd15113698040cb450c6a13f8e0165dba1c47f
+    name: perl-Devel-Peek
+    evr: 1.28-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Devel-SelfStubber-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14231
+    checksum: sha256:703faaef6ca5a65ed4c3cbdb256da9612eed842bd77620a2d527ca8d0fa8a7d2
+    name: perl-Devel-SelfStubber
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Devel-Size-0.83-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 34748
+    checksum: sha256:f932c1b7c88669289ce5d8988ea2f7e18008a47699661cee712377a4e6ae921b
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+    sourcerpm: perl-Devel-Size-0.83-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 29409
+    checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
+    name: perl-Digest
+    evr: 1.19-4.el9
+    sourcerpm: perl-Digest-1.19-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 39755
+    checksum: sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+    sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Digest-SHA-6.02-461.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 66199
+    checksum: sha256:07733b7a38f51154f07b24b1199d2beae019ba97b0b8666ec39148ead888b990
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+    sourcerpm: perl-Digest-SHA-6.02-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Digest-SHA1-2.13-34.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 56515
+    checksum: sha256:d0a7fc978c880803e23e34bbffd9824ca2b407d445271a7d6e361eac2843cd9b
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+    sourcerpm: perl-Digest-SHA1-2.13-34.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-DirHandle-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12337
+    checksum: sha256:2c79a7d1c783c4eb4305e7b15c885c7afc5e2612ab4b1245f4f9ef8dcff4804f
+    name: perl-DirHandle
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Dumpvalue-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18343
+    checksum: sha256:7659f1dab24e96da4be5624f90a3ac04b383071a96a32e185b196bc527377e1c
+    name: perl-Dumpvalue
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-DynaLoader-1.47-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25923
+    checksum: sha256:17266b2caf6162bfaa3f8fc73b11e47c61dd7c693e8de4dc28d6272c12e4e683
+    name: perl-DynaLoader
+    evr: 1.47-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Encode-3.08-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 1840299
+    checksum: sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Encode-Locale-1.05-21.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21500
+    checksum: sha256:58afacf30f4a476f4ba6646a6419122d2a729bd59880611b631527502dcdc269
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+    sourcerpm: perl-Encode-Locale-1.05-21.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Encode-devel-3.08-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 45159
+    checksum: sha256:a0e7ef9f5d70cb971d9d1568adb25dda7926ee3d9b7caec64c278c1e1178bd6b
+    name: perl-Encode-devel
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-English-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13497
+    checksum: sha256:04a48f25493933a3ae04eac446efefa1d4c092e323db1561e7653e4f570987da
+    name: perl-English
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Env-1.04-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22160
+    checksum: sha256:92fb2287084a3c88a6b2d2bd300d1279251cec59156c1a9a3e0fa8fda6c546b2
+    name: perl-Env
+    evr: 1.04-460.el9
+    sourcerpm: perl-Env-1.04-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Errno-1.30-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14836
+    checksum: sha256:4671dcf9af8cede4a768d2fbd7f1b8265ed55daf40ac04f1dd06d50bc1c2c2f1
+    name: perl-Errno
+    evr: 1.30-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 47552
+    checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
+    name: perl-Error
+    evr: 1:0.17029-7.el9
+    sourcerpm: perl-Error-0.17029-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 34509
+    checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
+    name: perl-Exporter
+    evr: 5.74-461.el9
+    sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 54624
+    checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+    sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16489
+    checksum: sha256:642338ff95d94e2c6e4b7de47cda7b772d1fbc204b2869925bd0326fcc4b0e26
+    name: perl-ExtUtils-Command
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Constant-0.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 47285
+    checksum: sha256:f10abe9f8d9f26c2ef2f278baf37a98e7a654cf192521d72bb797a3ef2131698
+    name: perl-ExtUtils-Constant
+    evr: 0.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Embed-1.35-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 17684
+    checksum: sha256:10fa80d9248c159ad12cce5222d3d1b82953ddfc7c4123ca0b14b5d5340e1421
+    name: perl-ExtUtils-Embed
+    evr: 1.35-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Install-2.20-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 48441
+    checksum: sha256:2533a1d97d45dc79c07cc51409c34f188c042757a2811b04dc16892ae2c7443e
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+    sourcerpm: perl-ExtUtils-Install-2.20-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-MM-Utils-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14176
+    checksum: sha256:51d7199c10886580e6cbff82546a34f26b2d5b894dcc338e28b1b55938f50ae3
+    name: perl-ExtUtils-MM-Utils
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 311769
+    checksum: sha256:2286e5004cb6436b7ac8dd436c91b4e1d36c18b9385d07a24fc167c930c9dee8
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+    sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 37829
+    checksum: sha256:f7cf7fd259fb8a6c27537dc98e1ed4923b26c2d8d8fd6b789e166ac104cac5bc
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+    sourcerpm: perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-Miniperl-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15171
+    checksum: sha256:6b00fb367aea4654a14495802d46daa87d2e51ee203a8b0e207edae507773edc
+    name: perl-ExtUtils-Miniperl
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 194711
+    checksum: sha256:bb7e4bcfe24371bbe202a9fa704360a7bbc5d9f4103ec36e6e571da6eb76a186
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+    sourcerpm: perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Fcntl-1.13-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 20193
+    checksum: sha256:d953c78c9e3f969e7a7d01827e04f3edce394b64e8346c74e1c8dce11f89ae73
+    name: perl-Fcntl
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Basename-2.85-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 17211
+    checksum: sha256:e39dcc13a24d3b5a7ba11288e63b22a055a8e1061743b8a409858d98ebd794e4
+    name: perl-File-Basename
+    evr: 2.85-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Compare-1.100.600-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13166
+    checksum: sha256:0dd800746b848a84fce73dcef035c4241e6aa90262c821a0ad295a7756ca1a4c
+    name: perl-File-Compare
+    evr: 1.100.600-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Copy-2.34-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 20143
+    checksum: sha256:165816db79e88e63c96bdafaf0c3bfee95b6feedb78e40da3a6dcc196a15a186
+    name: perl-File-Copy
+    evr: 2.34-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-DosGlob-1.12-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 19436
+    checksum: sha256:b0a817d4b57dabdef3ed689c28ff03a22293abebc62e4f752a2495db6429ab4a
+    name: perl-File-DosGlob
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Fetch-1.00-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 33372
+    checksum: sha256:8c46735b0f703cd53fbaf915423b63baf98701d81406b30b84e42e53a0efbb6e
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+    sourcerpm: perl-File-Fetch-1.00-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Find-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25551
+    checksum: sha256:002ec6d107fff6949f1a88965fb31b0a4efe6ce663395ab47e0cb939e3920c08
+    name: perl-File-Find
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-HomeDir-1.006-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 65857
+    checksum: sha256:68f539b86abb7ab910286188ad3742f4338330f3246f6da07cb4ca5c83d8e80f
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+    sourcerpm: perl-File-HomeDir-1.006-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 38466
+    checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
+    name: perl-File-Path
+    evr: 2.18-4.el9
+    sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 64150
+    checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+    sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-Which-1.23-10.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 24163
+    checksum: sha256:80a41f9f823312dca2c9fed97f6568a88957572277b75920fb76f20a60902e7f
+    name: perl-File-Which
+    evr: 1.23-10.el9
+    sourcerpm: perl-File-Which-1.23-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-File-stat-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 17117
+    checksum: sha256:b235134c1961e9b57f86bddc02e874607c17c155d2aa5ad78cc3ed9c8fd9c95b
+    name: perl-File-stat
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-FileCache-1.10-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14640
+    checksum: sha256:0b0ab9a79395bb7a926ec674b66f42845580903f514c511da156ffd497205f42
+    name: perl-FileCache
+    evr: 1.10-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-FileHandle-2.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15452
+    checksum: sha256:c2139abdb9b3335f592aa2835ef6d6fcde1e89232eb3d3c5a15f7cc1d0829f8d
+    name: perl-FileHandle
+    evr: 2.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Filter-1.60-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 96696
+    checksum: sha256:c9ce86cd03d331fd63b8d5c2370bc93c20035cf1b10d61ba383f923e1e3820ed
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+    sourcerpm: perl-Filter-1.60-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Filter-Simple-0.96-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 29899
+    checksum: sha256:080a1c4c16acddca179c0e2ab8120fe01e374bb86d0a950923a610e50fabfc00
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+    sourcerpm: perl-Filter-Simple-0.96-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-FindBin-1.51-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13872
+    checksum: sha256:44f9c97a57dafae68f8183d1ca2682a8308b68f1a399ab333a3dd52836bb6b17
+    name: perl-FindBin
+    evr: 1.51-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-GDBM_File-1.18-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21916
+    checksum: sha256:ffd1dbe85d5cf5f24adfa4a236a2ba1115ff92120a75794b6e837ba16df408f9
+    name: perl-GDBM_File
+    evr: 1.18-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 65144
+    checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+    sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15551
+    checksum: sha256:49bd8381823d680d17c37f3bebfd97dd92bfbf59e8019f15c7606f41dca02a7d
+    name: perl-Getopt-Std
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 38720
+    checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
+    name: perl-Git
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 58720
+    checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+    sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Hash-Util-0.23-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 34330
+    checksum: sha256:3b7d2627644afe4036affe2b0a205462ed8e36a0c55de4113b33c8afbfb2ed40
+    name: perl-Hash-Util
+    evr: 0.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Hash-Util-FieldHash-1.20-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 38009
+    checksum: sha256:eed12a5bfae764f463d54ad24241771ab66287ebcd7c6b821c2d1c725c16bab6
+    name: perl-Hash-Util-FieldHash
+    evr: 1.20-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-I18N-Collate-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14091
+    checksum: sha256:82a82eb1e6765c7b4ec245a624f34e73d6a7b2c9c15a90007bcbb64113332793
+    name: perl-I18N-Collate
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-I18N-LangTags-0.44-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 55212
+    checksum: sha256:f0849fe10730cf503bebfbd82e3dfb39d64ef87667ee9a1a073df8fd231878d6
+    name: perl-I18N-LangTags
+    evr: 0.44-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-I18N-Langinfo-0.19-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22316
+    checksum: sha256:b9c8370e1f733417832123e79879bbfe5e314b46a56b1a4acae0298751aaaeed
+    name: perl-I18N-Langinfo
+    evr: 0.19-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-1.43-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 90057
+    checksum: sha256:142c601e6928293f17dddbdcdb8f5691fa1f42b12c94fb0654c634e6d8f3d83b
+    name: perl-IO
+    evr: 1.43-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-Compress-2.102-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 280708
+    checksum: sha256:ce8f2004395442fe663cb9efc56f9af2102c75d746f2ce393e40af8a26ac6871
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+    sourcerpm: perl-IO-Compress-2.102-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 84153
+    checksum: sha256:bda4c005c09e886ce2273a3f418f0cd92521ed0b8fdcdaca7b9fc0026f2a6c7b
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+    sourcerpm: perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 46457
+    checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+    sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IO-Zlib-1.11-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21809
+    checksum: sha256:87d7b757a570fb53d72b2dd29558c2b4a8ff33196a80ad10f76999325acaec07
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+    sourcerpm: perl-IO-Zlib-1.11-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IPC-Cmd-1.04-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 42803
+    checksum: sha256:353b04bed7229ce354a4d63ba213c4e18fe739c4732061957946b84853d5b3ce
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+    sourcerpm: perl-IPC-Cmd-1.04-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22968
+    checksum: sha256:7ea36dcf28da3fc7250eb041ba19f99c87543c0870f5da67da614f5ca8d18b92
+    name: perl-IPC-Open3
+    evr: 1.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IPC-SysV-2.09-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 47649
+    checksum: sha256:ac4411e71c11743182bff435b7ec7f0c050614d3a0c9e41ebb9226bda5b9c441
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+    sourcerpm: perl-IPC-SysV-2.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-IPC-System-Simple-1.30-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 44255
+    checksum: sha256:35792b1aa241cb17b881b1e44940bc295329a575a2a2d183757ef1d757062465
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+    sourcerpm: perl-IPC-System-Simple-1.30-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Importer-0.026-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 42526
+    checksum: sha256:1afb9008ad841ba4fc207af8ec814d06bd78e958cd2b03089c7b82c71a311060
+    name: perl-Importer
+    evr: 0.026-4.el9
+    sourcerpm: perl-Importer-0.026-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-JSON-PP-4.06-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 70596
+    checksum: sha256:17f547d40976904eb59449f0cdec890e34632a28a083fc46157ac1c67e9e3494
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+    sourcerpm: perl-JSON-PP-4.06-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Locale-Maketext-1.29-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 101003
+    checksum: sha256:97cfef112a414049f85495cbec570b8c63d7260410f72cb2e1480a67fc7e9e68
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+    sourcerpm: perl-Locale-Maketext-1.29-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Locale-Maketext-Simple-0.21-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 17604
+    checksum: sha256:206fca125c5520e6e0723c6f8ee4c9b56d5bec95c7d71e4b54fdad36ddf20980
+    name: perl-Locale-Maketext-Simple
+    evr: 1:0.21-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 34885
+    checksum: sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+    sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-MIME-Charset-1.012.2-15.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 54488
+    checksum: sha256:cf481c2178bc2a55c5b455749f38f4f96ee71f32dcf458c34d4f1bbcb996feca
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+    sourcerpm: perl-MIME-Charset-1.012.2-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-MRO-Compat-0.13-15.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22804
+    checksum: sha256:7921d8fd6d4dacdfb4a286fe4355516f20d660681abb49af9983f7527429e351
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+    sourcerpm: perl-MRO-Compat-0.13-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 198900
+    checksum: sha256:b90555cc3da95e314e931de2348d7c89da7c16023fb9399cdfbbcf9f1aeade7d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+    sourcerpm: perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32035
+    checksum: sha256:df95e573bdf21c06a1083c80ff7f19dafbff3ccc7d272d5791a30a5bb2decf42
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+    sourcerpm: perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Math-BigRat-0.2614-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 42414
+    checksum: sha256:c31888896769451095c352ea97a1c88e2bbbc27d5bdc1e018dc8bae680967fb0
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+    sourcerpm: perl-Math-BigRat-0.2614-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Math-Complex-1.59-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 47421
+    checksum: sha256:754d5798c9a2bb21714671fdf0236e5937511bf59c473fdef8117c512410e8b5
+    name: perl-Math-Complex
+    evr: 1.59-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Memoize-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 57798
+    checksum: sha256:f668ee6ce94bab8e3a926587a1ab2f4ed3a4490d911c2e7fc1b2fe074a6cfdcc
+    name: perl-Memoize
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Build-0.42.31-9.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 274094
+    checksum: sha256:9e33e1a46048d262ebe06f98c6c7b1579cdf92db57b0bb4228d13883c232d82c
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+    sourcerpm: perl-Module-Build-0.42.31-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-CoreList-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 92615
+    checksum: sha256:fe85ea513ac696ce4d4bd5565259d89edde346d5a049d0eed153eac988ef73fd
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-CoreList-tools-5.20240609-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18135
+    checksum: sha256:2df9f5a5329e94c19bab88ba530149a86438756c7404787b03745f711adf3368
+    name: perl-Module-CoreList-tools
+    evr: 1:5.20240609-1.el9
+    sourcerpm: perl-Module-CoreList-5.20240609-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Load-0.36-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 20052
+    checksum: sha256:ada066ac44fd73ec87ea376a6d6715cf77b086354217fdc7a197c909da3bb099
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+    sourcerpm: perl-Module-Load-0.36-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25464
+    checksum: sha256:58a5364d77607678e4e628f5bdd3d33641e2f6083c2985c1bc5045401ae65a60
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+    sourcerpm: perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Loaded-0.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13245
+    checksum: sha256:5873834f46d56066cab07a5386daccf8b4db7ccf23344967dcdc31a893907778
+    name: perl-Module-Loaded
+    evr: 1:0.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Metadata-1.000037-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 39221
+    checksum: sha256:f053b34c911e5f3daf16c0ffc5ff752f47a0d016e1cc1ac51d4425fbe2a1ac15
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+    sourcerpm: perl-Module-Metadata-1.000037-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Module-Signature-0.88-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 89282
+    checksum: sha256:1a173631124cdb77ffa2cb11ceb8de813f6e4222e5bf9ae657947211480858e6
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+    sourcerpm: perl-Module-Signature-0.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14781
+    checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+    sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-NDBM_File-1.15-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21607
+    checksum: sha256:9a681f45dc6d0e2d023aa40d198690e68364807fc878d00f22ae409a53643297
+    name: perl-NDBM_File
+    evr: 1.15-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-NEXT-0.67-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21043
+    checksum: sha256:30c7f7f97f369fb9264c0c01f7f12fe1791c99e920aebdf149d71f945f814ec6
+    name: perl-NEXT
+    evr: 0.67-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Net-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25539
+    checksum: sha256:2bb0dceeec12a995caf29411056c2108a6f09b6bbe6d31090114fa4cbec53454
+    name: perl-Net
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Net-Ping-2.74-5.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 53027
+    checksum: sha256:fb74fb2651f62421538bb05992af5251887013a72c4412f5c2421992204c03bc
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+    sourcerpm: perl-Net-Ping-2.74-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Net-SSLeay-1.94-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 416368
+    checksum: sha256:2693afa05585d73923e30f2e7d878cb6c99c43c13aaaf57dfb08b12d83870d1e
+    name: perl-Net-SSLeay
+    evr: 1.94-3.el9
+    sourcerpm: perl-Net-SSLeay-1.94-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ODBM_File-1.16-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21695
+    checksum: sha256:45a028de0e5432e06d0476ddbde1c9838b53b42bfb2a0a97df1c193870dd5ff7
+    name: perl-ODBM_File
+    evr: 1.16-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Object-HashBase-0.009-7.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 28938
+    checksum: sha256:2144d4c29ea4acfc0d872bf09cb4d9dce14a64e60a45633f1a31ed3a2b125ee8
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+    sourcerpm: perl-Object-HashBase-0.009-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Opcode-1.48-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 36439
+    checksum: sha256:69c54562a1329d98f2ac19e8f61ae1535311642fc09ee1f4fa8fb2f1adadde91
+    name: perl-Opcode
+    evr: 1.48-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-POSIX-1.94-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 96517
+    checksum: sha256:c7b398d7d161fdcc5c8a9ad5a1fc7a03c548629d780c617e79f53892bd295f3d
+    name: perl-POSIX
+    evr: 1.94-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Package-Generator-1.106-23.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 26822
+    checksum: sha256:2c9b4699185c30d1da293add16911555e93b7532d77e59aa07e2c9c8d8eafcf3
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+    sourcerpm: perl-Package-Generator-1.106-23.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Params-Check-0.38-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 24764
+    checksum: sha256:a6cf1009e3f1dfe50e00421b11d43c413e7e4ee8c6931195256a3cb40e1baf7b
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+    sourcerpm: perl-Params-Check-0.38-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Params-Util-1.102-5.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 38351
+    checksum: sha256:de0b607392a3994f5b3e5a01a8912d15e7b9a1a069f83695fb2e1372cfa6e84b
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+    sourcerpm: perl-Params-Util-1.102-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 94193
+    checksum: sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0
+    name: perl-PathTools
+    evr: 3.78-461.el9
+    sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Perl-OSType-1.010-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 26284
+    checksum: sha256:64f37a98e22fce4ee9520da6db13ab601e21e34ac9d3ae7f85fc7a63761c492b
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+    sourcerpm: perl-Perl-OSType-1.010-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25566
+    checksum: sha256:31d1284cda8a84f78574ae2380474412788de756613bcb11a85d68c94af9ba0b
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+    sourcerpm: perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Checker-1.74-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 35171
+    checksum: sha256:7410aed54bb1c0a18b7b0ec33b6067475383b557defdd295b48b3277229d31a1
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+    sourcerpm: perl-Pod-Checker-1.74-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 22564
+    checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+    sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Functions-1.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13531
+    checksum: sha256:8afc31372f05f71a11054c7d7318301d3d65547abc7eac3ed56d428843edae0c
+    name: perl-Pod-Functions
+    evr: 1.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Html-1.25-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 26780
+    checksum: sha256:f692dea024e6ced870a5f792db9e76e06d810dfce9846bb59e5b4442b28820e6
+    name: perl-Pod-Html
+    evr: 1.25-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 93727
+    checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+    sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 234403
+    checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+    sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 44477
+    checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+    sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Safe-2.41-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25188
+    checksum: sha256:ca9095157a26e3ee611c9b9ef6c075086a2381571fccc1a45ade5f8f88c5a78e
+    name: perl-Safe
+    evr: 2.41-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 76007
+    checksum: sha256:91ab5182f214cab34e0d60512f49b47cb955880c85473223235a1a7b3d363587
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Search-Dict-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12900
+    checksum: sha256:f57497238bbc4edb96b24f88084e5d21f4e3aebab5d33a6db5e79a2ea53ce70d
+    name: perl-Search-Dict
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-SelectSaver-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 11553
+    checksum: sha256:8ec404df551d6cc4750efa34b9897d2288d07a26d49cd3d3d2315584976932b0
+    name: perl-SelectSaver
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-SelfLoader-1.26-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 21729
+    checksum: sha256:18a1b56a5a1097748cc998cb5305f5d77e253a05bae807b418694805fc413c8e
+    name: perl-SelfLoader
+    evr: 1.26-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Socket-2.031-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 59192
+    checksum: sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+    sourcerpm: perl-Socket-2.031-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Software-License-0.103014-12.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 147494
+    checksum: sha256:c225b78b513fc8b90a0b2b773fadcf65dd2defe2a147fca67c52971d2750f437
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+    sourcerpm: perl-Software-License-0.103014-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Storable-3.21-460.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 96993
+    checksum: sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+    sourcerpm: perl-Storable-3.21-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Sub-Exporter-0.987-27.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 78523
+    checksum: sha256:4e2535cd4d456f91f346e6d690c9a22c4b2a01318f9a5b5f761e1170d815bed1
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+    sourcerpm: perl-Sub-Exporter-0.987-27.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Sub-Install-0.928-28.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25233
+    checksum: sha256:4ce03d243d1331188c5a2b0e4103dad6b930ba36362cd353f0f3cd0998784e82
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+    sourcerpm: perl-Sub-Install-0.928-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Symbol-1.08-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14061
+    checksum: sha256:aa9942be4c837c024c6a0a376b13f9563e16ee8b66631ad6c5ff35cd0124728d
+    name: perl-Symbol
+    evr: 1.08-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Sys-Hostname-1.23-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16810
+    checksum: sha256:fcd2be791abd476384c8503b4c27bb1c604a76d13ee2d0532c182e2d8841b432
+    name: perl-Sys-Hostname
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Sys-Syslog-0.36-461.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 52359
+    checksum: sha256:359472155f87f9205f820d217dcc01d94ac711b8a39e9b2700968baefff5831a
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+    sourcerpm: perl-Sys-Syslog-0.36-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 52228
+    checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+    sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25043
+    checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+    sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-Complete-1.403-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12886
+    checksum: sha256:fe5f8688a2a28327a35be1caa35a9d7b8718531120ddfdb10da6f80d6b577059
+    name: perl-Term-Complete
+    evr: 1.403-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-ReadLine-1.17-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 19061
+    checksum: sha256:506c2fb3304f36ce437696dea9fb8772424a08345c765b25ac7278e429df1dcf
+    name: perl-Term-ReadLine
+    evr: 1.17-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-Size-Any-0.002-35.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16309
+    checksum: sha256:e83c29bb60e3fdac1c7aa5d3cde8a6b237812a14fe8f711bf6e127ed96d929a4
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+    sourcerpm: perl-Term-Size-Any-0.002-35.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-Size-Perl-0.031-12.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25151
+    checksum: sha256:36cf80e9d0e6be56c32c5aaf0e6633e45033540fd790d65748924d10d01f6743
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+    sourcerpm: perl-Term-Size-Perl-0.031-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Term-Table-0.015-8.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 40852
+    checksum: sha256:3e0c26e1b0e31d17cc133829ad8d6e22c86e532e9b6a3c26f48b7ec447bdfbb4
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+    sourcerpm: perl-Term-Table-0.015-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 40133
+    checksum: sha256:4a052241c855f5cb09d3661f3bf794df2a6170c3ce7f1f89ed64d868a5687599
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+    sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Test-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 28830
+    checksum: sha256:879484e27419a62c5eb942327570be90f246334000d9e3af1e052155b6e08661
+    name: perl-Test
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Test-Harness-3.42-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 306138
+    checksum: sha256:7980ae9e28aed0aadef4f169e8479812a2a6bacf05ee53001f63d021b065fe40
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+    sourcerpm: perl-Test-Harness-3.42-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Test-Simple-1.302183-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 645034
+    checksum: sha256:04ae40e07d57934e5dc3946fa638023ee76305dac04bed7813ed338b0a4c2ef2
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+    sourcerpm: perl-Test-Simple-1.302183-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Abbrev-1.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12026
+    checksum: sha256:7671d9b159be320b1725a11b9ba5a9d15b809ec22ba13e0ae5cacf5ed09fdec1
+    name: perl-Text-Abbrev
+    evr: 1.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Balanced-2.04-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 51500
+    checksum: sha256:67ff60f60b6dc900e840ed51ff3b1cabef9e43aa48cba81ad97ae9423bdca5af
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+    sourcerpm: perl-Text-Balanced-2.04-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Diff-1.45-13.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 45523
+    checksum: sha256:5141fc840dc2989b44df904df2cadfdc3b6b9d38a7e4dba2c2db3c14e3dbc060
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+    sourcerpm: perl-Text-Diff-1.45-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Glob-0.11-15.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15921
+    checksum: sha256:079d5eb4a606a131eaeecfcbd7f7d39a21c9c49b97bd6b84f7d08986dd11dc59
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+    sourcerpm: perl-Text-Glob-0.11-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18680
+    checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+    sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25935
+    checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+    sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Text-Template-1.59-5.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 64485
+    checksum: sha256:3c7350777e9d26fe4c02d52e8c4d4e0643ee32f8abfb9e22fc28f5325702924e
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+    sourcerpm: perl-Text-Template-1.59-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Thread-3.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18018
+    checksum: sha256:0caef6e47205d0035b3f692010e9f7dcd710e7832da77a2a5abbe930440f7e48
+    name: perl-Thread
+    evr: 3.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Thread-Queue-3.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 24804
+    checksum: sha256:88d838d681ad683970eb8566e8936faabffc3495dd1b555f083a1cd00538291a
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+    sourcerpm: perl-Thread-Queue-3.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Thread-Semaphore-2.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15604
+    checksum: sha256:136b09ee2841a1b6655f0a29759fe353b7f4b12ea3e559bafd39d4c508644925
+    name: perl-Thread-Semaphore
+    evr: 2.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Tie-4.6-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 31837
+    checksum: sha256:7144466ebb0d8dc2b7af2deac1dddd8caa23b35bcc0d42829c9b242b18f39d6c
+    name: perl-Tie
+    evr: 4.6-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Tie-File-1.06-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 43818
+    checksum: sha256:f99032921dc45c8a77f91909b5329a95fc4bade37815e2e866c70bf6f39a7c82
+    name: perl-Tie-File
+    evr: 1.06-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Tie-Memoize-1.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14038
+    checksum: sha256:1f3395cf1a045adfabf0e9b82bc4676f0dd1d76a985afedb3e069e6e9128c677
+    name: perl-Tie-Memoize
+    evr: 1.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Tie-RefHash-1.40-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 26260
+    checksum: sha256:5519a86c145d83a1633a127f7b0b6a371e6b2b8a647dabff45c2754388504a44
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+    sourcerpm: perl-Tie-RefHash-1.40-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Time-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18651
+    checksum: sha256:e23d1ba4c2e8d4283e757a7af563a24038b5829ed55c9bc90b4bae8c498ec5d7
+    name: perl-Time
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Time-HiRes-1.9764-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 61416
+    checksum: sha256:dd4edf12e362c0d60b4b0e1a1704a9a65d1f56178260c5f69ae206e55de34e32
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+    sourcerpm: perl-Time-HiRes-1.9764-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 37469
+    checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+    sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Time-Piece-1.3401-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 40898
+    checksum: sha256:ec6065935b13eaa3892b0b61ae5be6433ea0fc1c6e7095ed77c204db4ff7c4a5
+    name: perl-Time-Piece
+    evr: 1.3401-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 128279
+    checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
+    name: perl-URI
+    evr: 5.09-3.el9
+    sourcerpm: perl-URI-5.09-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Unicode-Collate-1.29-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 785136
+    checksum: sha256:7b739d35506eae140b014f33d20db87bbd1d3d49f95002de5c07e3bab1a35f9e
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+    sourcerpm: perl-Unicode-Collate-1.29-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 130851
+    checksum: sha256:101d364782f537de9fce7ad2cd0a253b642f0d729494dc5cc2a54d2adc784204
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+    sourcerpm: perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Unicode-Normalize-1.27-461.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 96377
+    checksum: sha256:be1da9f35d5c829879d150b3c8c025aec5d8255c6cf6301cf81555ece69a03ed
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+    sourcerpm: perl-Unicode-Normalize-1.27-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Unicode-UCD-0.75-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 79927
+    checksum: sha256:208f347f513df7c59ab77d90b54d3c9ed4cf67e733887783354a2c6ebeaf6409
+    name: perl-Unicode-UCD
+    evr: 0.75-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-User-pwent-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 20597
+    checksum: sha256:f131ac194a35b3b17f5ff6961e9bb9eb031fd5c7d0055e05a438c11b53931263
+    name: perl-User-pwent
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-autodie-2.34-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 103286
+    checksum: sha256:8c4a7c8fd5074801946cce0b0b2f47337036e7f64e4cb9c833d9cf1de1f14edc
+    name: perl-autodie
+    evr: 2.34-4.el9
+    sourcerpm: perl-autodie-2.34-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-autouse-1.11-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13668
+    checksum: sha256:c2502f538edef3d9b9ad20cdc8c0f8e971ac651df6c07f8555aa315b602c085a
+    name: perl-autouse
+    evr: 1.11-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-base-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16220
+    checksum: sha256:0be44f055107893b011ed0e88f39ff202ba451db8a94351ad4472d350c780d0d
+    name: perl-base
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-bignum-0.51-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 48635
+    checksum: sha256:a25963adbb78901e2581a041252bfc96f55e534403e4af513d8728c62f0b4800
+    name: perl-bignum
+    evr: 0.51-460.el9
+    sourcerpm: perl-bignum-0.51-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-blib-1.07-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12267
+    checksum: sha256:50560de5f252c718728c45cb7af3742252581416e0acb9cfacd686dad58c0028
+    name: perl-blib
+    evr: 1.07-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 25865
+    checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
+    name: perl-constant
+    evr: 1.33-461.el9
+    sourcerpm: perl-constant-1.33-461.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-debugger-1.56-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 136515
+    checksum: sha256:0b96f38c73512a61ce84171578bc9fcc5a957ff1fb267749f3af18bc7d1ce1bd
+    name: perl-debugger
+    evr: 1.56-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-deprecate-0.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14490
+    checksum: sha256:033aae2f09a7f78be08ae590f95cbce8025e5d5574cdab2bc77b554ad6e81575
+    name: perl-deprecate
+    evr: 0.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-devel-5.32.1-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 691911
+    checksum: sha256:7f4adba5c80eafeccfd0e0d1f9c32eb8662af1eef427ceaf528ccc81d5215260
+    name: perl-devel
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-diagnostics-1.37-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 215534
+    checksum: sha256:19c65175b0df9d6142bf08d6566b8f10c331735c8b95690adbc300b670a692c4
+    name: perl-diagnostics
+    evr: 1.37-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-doc-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 4798228
+    checksum: sha256:d9eb81a356338df906db80c853c092a1fb0de745726e82db44fb343d267b4091
+    name: perl-doc
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-encoding-3.00-462.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 65970
+    checksum: sha256:d516419a247fecaae2d60fb6a80c4990e07353e463e06b70a0d2db1f64723c35
+    name: perl-encoding
+    evr: 4:3.00-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-encoding-warnings-0.13-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16539
+    checksum: sha256:897e244bb8f8800a3ed23d669df746b0bb3672cd6929b06e04e5da63b04a5aa3
+    name: perl-encoding-warnings
+    evr: 0.13-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-experimental-0.022-6.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 24376
+    checksum: sha256:ae48d202863aba2573c70d803a9931de4e3c4b0d3e4f2df561bcc1bf78dc7920
+    name: perl-experimental
+    evr: 0.022-6.el9
+    sourcerpm: perl-experimental-0.022-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-fields-2.27-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16096
+    checksum: sha256:c2f5157686257ca7b67e566b4d7e86116c6c8b9f590023adf84fde78d35d3ea9
+    name: perl-fields
+    evr: 2.27-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-filetest-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14556
+    checksum: sha256:4556ac1a93588b9b3e3722867ef73680028e53b3aae4af87165a1a70c79530b8
+    name: perl-filetest
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-if-0.60.800-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13876
+    checksum: sha256:ae3ce80bee55e1057ed004ec03a0e826b0cdd90ace4c0784ab2f569a2d81d40c
+    name: perl-if
+    evr: 0.60.800-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-inc-latest-0.500-20.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 27665
+    checksum: sha256:22c41d7117656dfff8d52bc8e557e6f8d11d2b5ed377173f56037a2ac8bc9139
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+    sourcerpm: perl-inc-latest-0.500-20.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-interpreter-5.32.1-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 72012
+    checksum: sha256:f6096075a359219a341000b9eff41507dc8443f6fc88a43cef2cfe32feb86a3f
+    name: perl-interpreter
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-less-0.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13074
+    checksum: sha256:8c69534a3a191e28647b5c201dce163f2fa30f0813d54ace2345bbab830d7a9b
+    name: perl-less
+    evr: 0.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-lib-0.65-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14823
+    checksum: sha256:c013123fbff6efcf263d330ffb1f07c5e8a0413f1137379a52852234bdb1529b
+    name: perl-lib
+    evr: 0.65-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 137289
+    checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
+    name: perl-libnet
+    evr: 3.13-4.el9
+    sourcerpm: perl-libnet-3.13-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-libnetcfg-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16266
+    checksum: sha256:fcb262ee807d950b902ca12744cb2645c52de5aae0d9380a7ff4dd5574aec7fd
+    name: perl-libnetcfg
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-libs-5.32.1-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 2265296
+    checksum: sha256:3fe303c71a0eb8c9382a1d108a5dd117ee8f61992bf909c45f709ed220511c03
+    name: perl-libs
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-local-lib-2.000024-13.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 73510
+    checksum: sha256:c8f58afb9e8eb07bc57f92c384753ee4f4fec10fa7ec7c091ad9f15110a10026
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+    sourcerpm: perl-local-lib-2.000024-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-locale-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13543
+    checksum: sha256:6b81563677505210a973fd4416f5991bf729c03f3082ac139460290643daef33
+    name: perl-locale
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-macros-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 10568
+    checksum: sha256:e499fae237cea4dcec9480576b64c69afe91c09875a8dfcf9b4daebdbeb9f197
+    name: perl-macros
+    evr: 4:5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-meta-notation-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9577
+    checksum: sha256:0b7fb715954c7f67719f00bc7323d4a12453aab37acadba5106758f864c8535a
+    name: perl-meta-notation
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-mro-1.23-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 27910
+    checksum: sha256:a19e79da07703b88dfc51c25ec82f0203eb12558129f1ac0d311184e767b8dac
+    name: perl-mro
+    evr: 1.23-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-open-1.12-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16407
+    checksum: sha256:f3e192485674a0681320f38c4163460ce0bf4855b7e825f75c371f3b3a7c778f
+    name: perl-open
+    evr: 1.12-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-overload-1.31-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 46157
+    checksum: sha256:f172df7417780cb61b879effe60ce6b7b4399773c46cb9896a5edf2bfba6dbda
+    name: perl-overload
+    evr: 1.31-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-overloading-0.02-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12747
+    checksum: sha256:4aae487e802df60e1e2d778b264592290ad492078877784771299561d45dfd47
+    name: perl-overloading
+    evr: 0.02-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 16286
+    checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
+    name: perl-parent
+    evr: 1:0.238-460.el9
+    sourcerpm: perl-parent-0.238-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-perlfaq-5.20210520-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 388755
+    checksum: sha256:e5588c37edf2bb614ffb7526deb663bc406effb86492637b4c906c5fe06f0b98
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+    sourcerpm: perl-perlfaq-5.20210520-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-ph-5.32.1-481.1.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 41180
+    checksum: sha256:bf2c5015a5752e2d57da1494517a26b7cf3bb34b8d3e02e5896ad22c2c266822
+    name: perl-ph
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 121317
+    checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+    sourcerpm: perl-podlators-4.14-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-sigtrap-1.09-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 15624
+    checksum: sha256:5b7215d5421f381137e867678492848574c2ceb58e56d47d7833d182923e92c6
+    name: perl-sigtrap
+    evr: 1.09-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-sort-2.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 13408
+    checksum: sha256:554155e6ff38d091ea388b1f19fc0b0950522b4c4ffe87cfee3676c4f03c046d
+    name: perl-sort
+    evr: 2.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9639
+    checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
+    name: perl-srpm-macros
+    evr: 1-41.el9
+    sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-subs-1.03-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 11525
+    checksum: sha256:0a7ef4a9a174ab981949d27a4acdc8cec87fd3513e9e607f5869851dc1c74deb
+    name: perl-subs
+    evr: 1.03-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-threads-2.25-460.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 61664
+    checksum: sha256:129a9239763d667a074133a62564a3ee0e0b16afafe049266083edd081df9e1c
+    name: perl-threads
+    evr: 1:2.25-460.el9
+    sourcerpm: perl-threads-2.25-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-threads-shared-1.61-460.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 47922
+    checksum: sha256:83816aefd6d15b0c2b6efccadfa67ccf50832c6849d2664d5c2d84e01d7da75b
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+    sourcerpm: perl-threads-shared-1.61-460.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-utils-5.32.1-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 55943
+    checksum: sha256:5c21992a23a63139c0c73ce0b9866cd9064ab2efc8d9414bb45edc6c72996162
+    name: perl-utils
+    evr: 5.32.1-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-vars-1.05-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 12885
+    checksum: sha256:5d3c58094c0158b6193d7f4ba7a4bb7ae06a78738393b31255da8b7aadb10e38
+    name: perl-vars
+    evr: 1.05-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-version-0.99.28-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 68117
+    checksum: sha256:5036498e5a93e0c493714c023c150add5d962926d7a5d7a374ee2321137df4c8
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+    sourcerpm: perl-version-0.99.28-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-vmsish-1.04-481.1.el9_6.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14031
+    checksum: sha256:af9db38df1c1843277ebd8c6bb8d766017be043eea28246252788b055f19764d
+    name: perl-vmsish
+    evr: 1.04-481.1.el9_6
+    sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/policycoreutils-python-utils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 77697
+    checksum: sha256:342fa73cc94923b8ce94c4dc6ecb6f8e489b1ecfc7574ed04b93824e061c1c57
+    name: policycoreutils-python-utils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/pyproject-srpm-macros-1.16.2-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 14828
+    checksum: sha256:1bec3715412a73295a9cd2cdbc147ebee0fe23b50f4146bddc08a5761ed3928d
+    name: pyproject-srpm-macros
+    evr: 1.16.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 18705
+    checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
+    name: python-srpm-macros
+    evr: 3.9-54.el9
+    sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 79956
+    checksum: sha256:0b7840c3b5422d7fea9bb557e8dca09949305b3eb3b4e78c4f06b7eabc4f48c2
+    name: python3-audit
+    evr: 3.1.5-7.el9
+    sourcerpm: audit-3.1.5-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 190360
+    checksum: sha256:9b63e1e8127bef69a37c2486fec1b7be29c1719dd8f23b92ca88abae7a9d466b
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 82324
+    checksum: sha256:e02938adb70a3b7533980c3f0b39b06b3d2e5fb51066e3aabb81ebd041a58253
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3-policycoreutils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 2210974
+    checksum: sha256:db891ec3a74ccdd7ab2f9cf0a4436e7df3e6702eb483cd111421f79a334e4aea
+    name: python3-policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9344
+    checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
+    name: qt5-srpm-macros
+    evr: 5.15.9-1.el9
+    sourcerpm: qt5-5.15.9-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/r/redhat-rpm-config-210-1.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 72050
+    checksum: sha256:ad59b922bf8028d3021c74123d33ef770a500dc7b0dd16a34301b0fcc09c6af4
+    name: redhat-rpm-config
+    evr: 210-1.el9
+    sourcerpm: redhat-rpm-config-210-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/r/rust-1.88.0-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 31184880
+    checksum: sha256:33536795f2f65b928b78a2c2238dadb5cec5df8234d17f3347b3112e2fe826fd
+    name: rust
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 11243
+    checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
+    name: rust-srpm-macros
+    evr: 17-4.el9
+    sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/r/rust-std-static-1.88.0-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 39210792
+    checksum: sha256:9f4514885ab9d25ccda42e076381cf44e2da05c15a3a032204fcbcb34783fa93
+    name: rust-std-static
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 42078
+    checksum: sha256:7cca48a078a95be13fdd27ffcce12a35a962712ebf44de2b6bd2a948fc93a806
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/sombok-2.4.0-16.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 51525
+    checksum: sha256:1e6e424ba9e43a503c97d6c95c34e711450eb7f0ba92a560c3995b1d9cbae44a
+    name: sombok
+    evr: 2.4.0-16.el9
+    sourcerpm: sombok-2.4.0-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/systemtap-sdt-devel-5.3-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 70543
+    checksum: sha256:8c84da584ebd7452d56eed0f4cd36d3461065db411438e94cb3dce6510ded335
+    name: systemtap-sdt-devel
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/systemtap-sdt-dtrace-5.3-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 71474
+    checksum: sha256:f5109993f2010bcbfe33282ffe8b8b48591fde637d0077b3f19070533347e299
+    name: systemtap-sdt-dtrace
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/b/binutils-2.35.2-67.el9_7.1.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 4757228
+    checksum: sha256:008f134e067d162aac5bd2d8a8172ca1c3819575250d976fa617c00ac5153c1a
+    name: binutils
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/b/binutils-gold-2.35.2-67.el9_7.1.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 843893
+    checksum: sha256:f84ad1e1fb5f348d4e40f89a77043ff7fa10b3891f4cfa69513761e494f06373
+    name: binutils-gold
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/c/cyrus-sasl-2.1.27-22.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 73251
+    checksum: sha256:82e9e2f260fd17ddad731566e629ef0b4c2fb91a28321e5a576b4be8d5917c1e
+    name: cyrus-sasl
+    evr: 2.1.27-22.el9
+    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/d/diffutils-3.7-12.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 410465
+    checksum: sha256:a8015025ca40048059576a71f398c47d4b563e6a91e1e27a453f9212312df259
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/e/elfutils-debuginfod-client-0.193-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 44248
+    checksum: sha256:a4a86d067ccd917e0c68753f19731f307256ed40fcad7344b2b06aba5c6930c8
+    name: elfutils-debuginfod-client
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 604248
+    checksum: sha256:170326278e5bf85fb830c599104a92cdcbe096e36608e42cf797c8fd34caf2c4
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/f/file-5.39-16.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 52878
+    checksum: sha256:66c999a4e1fabdc8bf5202fa9e852a2e9fb371bcbc99fc5148091bfe4536f3d9
+    name: file
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/glibc-gconv-extra-2.34-231.el9_7.10.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 1751293
+    checksum: sha256:74f10e1a1aacff9937ca93ab7d6063f142629b12de9d9ffa8066922871615d35
+    name: glibc-gconv-extra
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/groff-base-1.22.4-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 1100747
+    checksum: sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/j/jansson-2.14-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 47657
+    checksum: sha256:3da6821430545cab897d8119cc63c24c7dde32a8604b89f4fc0dd98beaf2714a
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/less-590-6.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 166698
+    checksum: sha256:63241d59d1ce7164d516ff360b6186ab8c7b49e642a48ed0f09c55451ea26beb
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libatomic-11.5.0-11.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 23203
+    checksum: sha256:02baad58ec2a83f3a86e7f4cf8f0b3f75b73360600b4b265bc115e12c07de7d1
+    name: libatomic
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libcbor-0.7.0-5.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 59841
+    checksum: sha256:585939d5b06976e1d053d3d7e5751fe4bc98759c03deb13f85ea5b21150acfd6
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 107657
+    checksum: sha256:7e6661f35f325ac458e1c6ba5e18ccb49685a043cef5296155be1124fd5e8d86
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libfido2-1.13.0-2.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 95761
+    checksum: sha256:7c84d840d3698b9632d7922a86746a9b9620f9d8c094d54c753a2ef660ef3291
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 52473
+    checksum: sha256:9319d8a68483d71eb367f8f8d609f3f2154aea65e17345ceba55bdb32a74722e
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 37876
+    checksum: sha256:fa1da3b44d85663cceaa0faf8eb5f2f7325cc83c381d6018f303edd06cab5938
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 197292
+    checksum: sha256:315c92b1796174b7c43dfec36440f8cba66e223cfbed922c6978a4bfe4983c6d
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/m/make-4.3-8.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 553451
+    checksum: sha256:09c0e578e23112cb98e2234f9587fe7b6def2ae6a4b16e6d52559d546389f4d1
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/m/man-db-2.9.3-9.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 1236388
+    checksum: sha256:fe5f86aeb50c609b7df9075e568fee45ec208bced8264913aec83bf4d7cacbea
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/n/ncurses-6.2-12.20210508.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 417044
+    checksum: sha256:b0a2b5af6064364443e6645b3ae36cc420ae3f66bafb7b782da90ce013ca7011
+    name: ncurses
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/o/openssh-8.7p1-48.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 459811
+    checksum: sha256:f0d5f3b02fbbdf785b310d54755b6994050b2067a632a230d79db33bb7d76633
+    name: openssh
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/o/openssh-clients-8.7p1-48.el9_7.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 689011
+    checksum: sha256:894c0c9fae5b1a5d85b642994dd48bd577821ce394f377abe068c83eda9fa9a2
+    name: openssh-clients
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 45258
+    checksum: sha256:a5f966f792cacc4696e4187593a915fb56452dd272cf4c81d930968adb3ee00c
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 12411
+    checksum: sha256:ef854bfe75102d994afb58510121164c4b9b8359b7d983cd8904c425a175b750
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/policycoreutils-3.6-3.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 243581
+    checksum: sha256:fd6fa46e3beebd272a967f01d5643a5b06a680f3b72d92f2c9c2c0c46075efe8
+    name: policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 354331
+    checksum: sha256:540d734809d1a9ef380a47c5ef3039b2ab736bea53ba8f34d2456d654dc92f1b
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 157800
+    checksum: sha256:4c7b1bbabe7f37d1dd098c9d893f7f8e97e5fd43aa8fa4d4c58a3b6b66e69c70
+    name: python3-pyparsing
+    evr: 2.4.7-9.el9
+    sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 599860
+    checksum: sha256:71afade33b960abc643c3be442ee590ed1c845f07f4877ae65b76761104cbd8b
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/t/tcl-8.6.10-7.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 1120943
+    checksum: sha256:2c05d698a7cced9313984349224a327b06d96a5bc696645bdafe7a41fb159da6
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/u/unzip-6.0-59.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 180857
+    checksum: sha256:0c4ec86b4b30a4309f6c8649ab3f23d8a351ea82d301e036e27b8dbb08349c13
+    name: unzip
+    evr: 6.0-59.el9
+    sourcerpm: unzip-6.0-59.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-23.el9_7.2.noarch.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 20860
+    checksum: sha256:e3fc2d706b1e395043a8a9bc76bb04c1ef7174269c840cb73176d00260df2724
+    name: vim-filesystem
+    evr: 2:8.2.2637-23.el9_7.2
+    sourcerpm: vim-8.2.2637-23.el9_7.2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/z/zip-3.0-35.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 276776
+    checksum: sha256:ac9f81e15ac141940073706ed38e3efd1d2278642d80dbd2945b28f0e6ffae62
+    name: zip
+    evr: 3.0-35.el9
+    sourcerpm: zip-3.0-35.el9.src.rpm
+  source: []
+  module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/annobin-12.98-2.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/annobin-12.98-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 1121890
-    checksum: sha256:a27f53f146f65d077290eccdd1a4fd58c2a761a31baad860aa4961961d52d509
+    size: 1117414
+    checksum: sha256:604af902dd8793f42ed3f30a9a6c78e2cebe74d4924479e8647b4d3224be328a
     name: annobin
-    evr: 12.98-2.el9
-    sourcerpm: annobin-12.98-2.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.92.0-1.el9.x86_64.rpm
+    evr: 12.98-1.el9
+    sourcerpm: annobin-12.98-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.88.0-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9100626
-    checksum: sha256:3c4afc2cb56734d01aaaaa8d0c317688f6fe143ad239079342f4fe9b631ded0f
+    size: 8326606
+    checksum: sha256:8d5b570c23f08d8e619cd9d69f4e6a25572cc4df0747f9cdc8c531621ce45480
     name: cargo
-    evr: 1.92.0-1.el9
-    sourcerpm: rust-1.92.0-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 13989883
-    checksum: sha256:e67ea7aef1edd470e4ec22982e97871655abcdc0990754d4e8f147d4e7de317a
+    size: 365931
+    checksum: sha256:3d12bc7e21276434108c97561f75d1854283afb73d4fface3b836acee09f8d98
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-20.1.8-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 157998
+    checksum: sha256:46864209cb88c9a10c4754f41975fc8fa522951a75a0a5c50983a2e17ec6deb4
+    name: clang
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-libs-20.1.8-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 30159102
+    checksum: sha256:3c6ff301c829469886ba0adf4892094ef967c6506da6f70d33b12a801b5d44b0
+    name: clang-libs
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-resource-filesystem-20.1.8-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 15006
+    checksum: sha256:c2bcd54b9a64a9ae2129d21e67adfcd53971b61d507e2a0dd985c78dc45d8f07
+    name: clang-resource-filesystem
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.26.5-3.el9_7.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 9138295
+    checksum: sha256:b633e1bff169d2965bb40c3a5e1e0260f0ddd64ea8cb5fa61bc213eb070be869
     name: cmake
-    evr: 3.31.8-3.el9
-    sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.26.5-3.el9_7.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2829291
-    checksum: sha256:1cdc2e88a996c575b750483c8f562674e4b50a6ab414c7bbe6f6b641c1db7bd9
+    size: 2483069
+    checksum: sha256:6b8afdf96d315c36df391e0f170d5ba845d11704549c4ffa3533aa43922d722e
     name: cmake-data
-    evr: 3.31.8-3.el9
-    sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.26.5-3.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 19309
-    checksum: sha256:b5ea81385a9e4e6a1ae2bb1175cd774af82f9c570a37008cde873ead466ba5f7
+    size: 18599
+    checksum: sha256:6351f8577c02aecbee1a3e83592532a7e4ce4612c72ef237f097db75c90e7dc4
     name: cmake-filesystem
-    evr: 3.31.8-3.el9
-    sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
+    evr: 3.26.5-3.el9_7
+    sourcerpm: cmake-3.26.5-3.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compiler-rt-20.1.8-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 11226193
-    checksum: sha256:3c0ee1cb8b72f3f5176f8945ab518eb733ccc9f950d317fb5d5ac327d0eb9c90
+    size: 2844970
+    checksum: sha256:169c3ef7f52ea8f6a186e7b61b0d17bd7d4cbf64475b7283aa3ce0e9de367362
+    name: compiler-rt
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-11.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 11224872
+    checksum: sha256:421a6f9e65d57c0b34128d7c5712c6617d87f7fc2fa896feb291f01aede6c4d2
     name: cpp
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cyrus-sasl-devel-2.1.27-22.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 113776
@@ -81,27 +7912,62 @@ arches:
     name: fonts-srpm-macros
     evr: 1:2.0.5-7.el9.1
     sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-11.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 33982584
-    checksum: sha256:2082784165bbb246b6e5ef5921ed823f0a9709cacdf5823aa60695fd6d4819a2
+    size: 33986019
+    checksum: sha256:9d6a29987112382e29640de757c7d6360b5742e8bded1696b335b5e98898acb9
     name: gcc
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-11.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 13474286
-    checksum: sha256:b073d8965ad8eed7520a2a1c9b7c961232511ad9188dcc8c92356160a9d51e37
+    size: 13478056
+    checksum: sha256:b1eb2b69b5bdfb10dcd7fdba099659bd28996a80c17c5cde23d95a0467f5ee09
     name: gcc-c++
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-14.el9.x86_64.rpm
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-11.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 38017
-    checksum: sha256:9a299bb69938f497a041e8026f35a0d1042559a7f582a4e9e2a683f3bf476ca8
+    size: 37748
+    checksum: sha256:bf2729c11d2b6e4898464debf449f632fa9e2bdc9f70e9f6febe196256ddf34d
     name: gcc-plugin-annobin
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-5.el9_7.1.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 6896416
+    checksum: sha256:dbfbac0be292bf4477871554383359079263e14fe63636ec7c53a1d82ead585c
+    name: gcc-toolset-14-binutils
+    evr: 2.41-5.el9_7.1
+    sourcerpm: gcc-toolset-14-binutils-2.41-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-12.el9_7.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 49277421
+    checksum: sha256:55fc00b6f0b036c968c698fa90b1e07ee8d46e4ba7706d08a675fcb4732cc4d8
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-12.el9_7.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 15456349
+    checksum: sha256:98de2360fe531b66fb8cea31f8ef898c16a936fa21da35ebd30b77283d601a86
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-12.el9_7.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 3823667
+    checksum: sha256:cb7bff31c52d646d638a7d660f81024173caba591114b5b9c3afb4f25d4aaa49
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-12.el9_7
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-12.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 58568
+    checksum: sha256:fd93bde11241e6ed3c9dbfad9ce9a9683645b9242ab679a7c7daeb314fdc3367
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9252
@@ -109,55 +7975,55 @@ arches:
     name: ghc-srpm-macros
     evr: 1.5.0-6.el9
     sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-2.52.0-1.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-2.47.3-1.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 46071
-    checksum: sha256:be1c2f855001bf01cb5c5b0ff59d8943ddc4c4eedbbbddd68474d2aa6e11395c
+    size: 51883
+    checksum: sha256:5097b6a0540e33dd02d581109cf1b10fcc736975c330208fae148efacb13b649
     name: git
-    evr: 2.52.0-1.el9
-    sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 5293286
-    checksum: sha256:6264aa556d583604f34def3674f5830a70cfee0aac283719e4df295db38acb53
+    size: 4926340
+    checksum: sha256:4056d5f982607b0c8106ad1467b396be4abf150d8532fe018c9dc469cf149411
     name: git-core
-    evr: 2.52.0-1.el9
-    sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-doc-2.52.0-1.el9.noarch.rpm
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 3300095
-    checksum: sha256:cf375cd9a48d244df37bb0c9ff58aa3c6f3d21d7446cc0cf902c9659fecf8343
+    size: 3195826
+    checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
     name: git-core-doc
-    evr: 2.52.0-1.el9
-    sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-270.el9_8.x86_64.rpm
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-231.el9_7.10.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 47451
-    checksum: sha256:ac596cb6c59f74558e4b9b3674abc34d79c9772c4165f5cda866c1c24c81f939
+    size: 44222
+    checksum: sha256:4bf307483b5c6c359b7484804c453ab5c6b0fc65c7cd5368e2572077d804d559
     name: glibc-devel
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-270.el9_8.x86_64.rpm
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-231.el9_7.10.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 568001
-    checksum: sha256:0eab0982c27442a8e4acbd7b32a66757174482dcc183ef27412427f54f8f36d7
+    size: 564682
+    checksum: sha256:dfabaa79899e36aa920d901851e5c2101d43b91d9f466dc97c35b4c14290d4e7
     name: glibc-headers
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/go-srpm-macros-3.8.1-1.el9.noarch.rpm
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_7.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 27276
-    checksum: sha256:36af44d720cfd9f5f368171c2f5033c7e58b8a81f4e4c12f49cb9885ce8f7050
+    size: 33806
+    checksum: sha256:ea2a392fd650fc6c4928590af98a4b35f705537b0353417599ba97c21b271404
     name: go-srpm-macros
-    evr: 3.8.1-1.el9
-    sourcerpm: go-rpm-macros-3.8.1-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.17.1.el9_8.x86_64.rpm
+    evr: 3.6.0-13.el9_7
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2851973
-    checksum: sha256:327d2fb943e75ecd6d5ed30bcaa240751ea4e11be091ff6aeb5ce36405a6afba
+    size: 3025981
+    checksum: sha256:551f1d5cb5981a364fd119aaeacaad54e69c886308a7aaba3b4fa2e507b58d5d
     name: kernel-headers
-    evr: 5.14.0-687.17.1.el9_8
-    sourcerpm: kernel-5.14.0-687.17.1.el9_8.src.rpm
+    evr: 5.14.0-611.47.1.el9_7
+    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14098
@@ -179,13 +8045,27 @@ arches:
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libomp-20.1.8-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2524816
-    checksum: sha256:2d031d05fe073adc74919b8372763ae322615d9df23f4a2c642050ab4b389ce5
+    size: 764808
+    checksum: sha256:14da467e38779215f3687dc3b9a27d31302d02f2248bfd42c95fe8df768264aa
+    name: libomp
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libomp-devel-20.1.8-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 287564
+    checksum: sha256:e0d8a91fcf16d7ed2d011a44ca7ad27d3935c06f32e521f7a04d0a1c112b9788
+    name: libomp-devel
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-11.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 2524732
+    checksum: sha256:68e2fcc6633e3f36b3c91316295f26bac30ecf33cfff247bef15ae41523928ff
     name: libstdc++-devel
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libthai-0.1.28-8.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 216254
@@ -207,20 +8087,20 @@ arches:
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-filesystem-20.1.8-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 20224
-    checksum: sha256:b54fc55927e26da6954bbf9a396735a2a29383b15fe9e3d70b9d24cd90b1c500
+    size: 9374
+    checksum: sha256:b1584007e959eddcba9b5c930ca001a741ce8c5db53b60c97a1eeb1483e0444c
     name: llvm-filesystem
-    evr: 21.1.8-2.el9
-    sourcerpm: llvm-21.1.8-2.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.x86_64.rpm
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-20.1.8-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 32586819
-    checksum: sha256:6c71c84a680f89a551b312eac90c9ae2899c3bdfaacdc809e39d7da968657d5a
+    size: 31501653
+    checksum: sha256:5ae29a9cf690992010987b3dfc8a249a869bfca8ae3a45178685411d7f70c358
     name: llvm-libs
-    evr: 21.1.8-2.el9
-    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+    evr: 20.1.8-3.el9
+    sourcerpm: llvm-20.1.8-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 10476
@@ -242,13 +8122,13 @@ arches:
     name: openblas-srpm-macros
     evr: 2-11.el9
     sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-4.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.1-7.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 5018420
-    checksum: sha256:b8bd95180ea457da07e0bf5e33c5425703df34ba25426266baec5336e18e5dea
+    size: 4998056
+    checksum: sha256:85e1a341adc784f4420742219e182f421655a5482aabe2b274445681747e1730
     name: openssl-devel
-    evr: 1:3.5.5-4.el9_8
-    sourcerpm: openssl-3.5.5-4.el9_8.src.rpm
+    evr: 1:3.5.1-7.el9_7
+    sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-5.32.1-481.1.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8429
@@ -571,13 +8451,13 @@ arches:
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-5.el9.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 48936
-    checksum: sha256:c34ba01c7ad3f0ab3e3381654a7ad84a848ea7553252860d72a8bc032c76b4af
+    size: 54624
+    checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
     name: perl-ExtUtils-CBuilder
-    evr: 1:0.280236-5.el9
-    sourcerpm: perl-ExtUtils-CBuilder-0.280236-5.el9.src.rpm
+    evr: 1:0.280236-4.el9
+    sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16489
@@ -781,13 +8661,13 @@ arches:
     name: perl-Getopt-Std
     evr: 1.12-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Git-2.52.0-1.el9.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 44211
-    checksum: sha256:3c57cee7cf3de7a79bef821448b01f48473d2fb9367509f57912a2f1ae7c3009
+    size: 38720
+    checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
     name: perl-Git
-    evr: 2.52.0-1.el9
-    sourcerpm: git-2.52.0-1.el9.src.rpm
+    evr: 2.47.3-1.el9_6
+    sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 58720
@@ -1859,13 +9739,20 @@ arches:
     name: perl-vmsish
     evr: 1.04-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pyproject-srpm-macros-1.18.5-1.el9.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-3.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 12794
-    checksum: sha256:de04df6652bd69cd9e30603c01c25924f13c847f1a1a6d89b5a3bc1283b20f40
+    size: 77697
+    checksum: sha256:342fa73cc94923b8ce94c4dc6ecb6f8e489b1ecfc7574ed04b93824e061c1c57
+    name: policycoreutils-python-utils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pyproject-srpm-macros-1.16.2-1.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 14828
+    checksum: sha256:1bec3715412a73295a9cd2cdbc147ebee0fe23b50f4146bddc08a5761ed3928d
     name: pyproject-srpm-macros
-    evr: 1.18.5-1.el9
-    sourcerpm: pyproject-rpm-macros-1.18.5-1.el9.src.rpm
+    evr: 1.16.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.16.2-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18705
@@ -1873,6 +9760,41 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 80734
+    checksum: sha256:aa0258ede786000d2993537d959115a741a5b86884d9f405bf6fb5a686560d3e
+    name: python3-audit
+    evr: 3.1.5-7.el9
+    sourcerpm: audit-3.1.5-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 196472
+    checksum: sha256:7af821a0ee7c7b56df79de25fe35cc2d0fd6f45df5c3bcec2c5e72d7378ba265
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 82730
+    checksum: sha256:8a17df19f0ff5dbb98fe608999cb2370983d8565658df01d0993b3028cbf28d6
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-3.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 2210974
+    checksum: sha256:db891ec3a74ccdd7ab2f9cf0a4436e7df3e6702eb483cd111421f79a334e4aea
+    name: python3-policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9344
@@ -1887,13 +9809,13 @@ arches:
     name: redhat-rpm-config
     evr: 210-1.el9
     sourcerpm: redhat-rpm-config-210-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.92.0-1.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.88.0-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 31511504
-    checksum: sha256:fbc70b11f38999206d70a104789d1f7f21ca9f9090c7a73d6db337bff4f5205b
+    size: 30892199
+    checksum: sha256:d976ea2f80c38598484e6e6e5501bc92f8581b94227dd554e0492bf5d2234f04
     name: rust
-    evr: 1.92.0-1.el9
-    sourcerpm: rust-1.92.0-1.el9.src.rpm
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11243
@@ -1901,13 +9823,20 @@ arches:
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.88.0-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 42991765
-    checksum: sha256:d286394aaa75a796a06db130d2a980bee8e6ab4cbaa38a3b84e12379fbae4671
+    size: 41209382
+    checksum: sha256:5ac616ad878773059445a8c8cbc8ee013541712b321435a9adff5989558a3227
     name: rust-std-static
-    evr: 1.92.0-1.el9
-    sourcerpm: rust-1.92.0-1.el9.src.rpm
+    evr: 1.88.0-1.el9
+    sourcerpm: rust-1.88.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 42223
+    checksum: sha256:164d245bec95c7dcbba881fd88ee567bc6d5859329c91ae05a6ad5429700bdbc
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/sombok-2.4.0-16.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52190
@@ -1915,34 +9844,34 @@ arches:
     name: sombok
     evr: 2.4.0-16.el9
     sourcerpm: sombok-2.4.0-16.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/systemtap-sdt-devel-5.4-4.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/systemtap-sdt-devel-5.3-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 69771
-    checksum: sha256:87ea7616759a71db33b780c20577d86de950dd7587e3af0dad879dd7bdbf7f19
+    size: 70576
+    checksum: sha256:e328e68656520f43deedad3d8d753e4e9914dbc77a92690fa9ba32ae0bdbe796
     name: systemtap-sdt-devel
-    evr: 5.4-4.el9
-    sourcerpm: systemtap-5.4-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/systemtap-sdt-dtrace-5.4-4.el9.x86_64.rpm
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/systemtap-sdt-dtrace-5.3-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 70547
-    checksum: sha256:d3c65038a01b917e334c54b27b403d92f467549462befddc7ca469d97f78adc9
+    size: 71499
+    checksum: sha256:771ab6c279bd79376b5ebf8f1fd42ce597c940f852c80a0efdd2c18fb0333a9f
     name: systemtap-sdt-dtrace
-    evr: 5.4-4.el9
-    sourcerpm: systemtap-5.4-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
+    evr: 5.3-3.el9
+    sourcerpm: systemtap-5.3-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-67.el9_7.1.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 4821853
-    checksum: sha256:bda706d43bf47267e31db8ac62fe3206122f97ff035daa6c93ce9cd5063a63ca
+    size: 4813551
+    checksum: sha256:1e7ccdae7390ee9323971fef398e41687eb39ca06242ca1ab673ed8b31e99184
     name: binutils
-    evr: 2.35.2-72.el9
-    sourcerpm: binutils-2.35.2-72.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-67.el9_7.1.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 758393
-    checksum: sha256:4d429d1030d8e1c610ba5aea83f8c63090033f440b2c8f788f0e0acd4a3c51b3
+    size: 751923
+    checksum: sha256:9dbb88e0bacb4985c5ae21b002fc2a2b2ad316ad3d8bd18e5f5a79729e92e9ee
     name: binutils-gold
-    evr: 2.35.2-72.el9
-    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+    evr: 2.35.2-67.el9_7.1
+    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-2.1.27-22.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 72615
@@ -1950,83 +9879,41 @@ arches:
     name: cyrus-sasl
     evr: 2.1.27-22.el9
     sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 786202
-    checksum: sha256:a85ebdee7a9a49990f87e4709c368212e6a54ecf18c88a3dd54d823a82443898
-    name: cyrus-sasl-lib
-    evr: 2.1.27-22.el9
-    sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
+    size: 411559
+    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.193-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 43826
-    checksum: sha256:1635fd1ecaa9492fa925956dfd56d10063ca336619218f124ab45df0a38b41b0
+    size: 44629
+    checksum: sha256:595b16ef65e5310e6091af8e9ff9dc378249ab3d739f7b02881b3eb33c9acce6
     name: elfutils-debuginfod-client
-    evr: 0.194-1.el9
-    sourcerpm: elfutils-0.194-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
+    evr: 0.193-1.el9
+    sourcerpm: elfutils-0.193-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 205864
-    checksum: sha256:00bbe4776149d8ccedcdf19dd6ceb08c3bb42ff41b98d744abe101af0b11a6c5
-    name: elfutils-libelf
-    evr: 0.194-1.el9
-    sourcerpm: elfutils-0.194-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
+    size: 604214
+    checksum: sha256:abee5229dce8c09f567626c0a6d741e8e3b30f8fd54d860365a25bec901cd680
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 274670
-    checksum: sha256:ad4f6d425cbc975cead56a2c982e38b0146d00944cbd9b3072d3d1f1271237a5
-    name: elfutils-libs
-    evr: 0.194-1.el9
-    sourcerpm: elfutils-0.194-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/file-5.39-17.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 55037
-    checksum: sha256:ad360b1c5aae98fcc41a212d5d69a8e8c6a5427b4c51418da18691dd09b18fa3
+    size: 53222
+    checksum: sha256:64f29bc71f9c26e6460abaff21d8e43738077cde4fbd6d1b96825a50ba0abd74
     name: file
-    evr: 5.39-17.el9
-    sourcerpm: file-5.39-17.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/file-libs-5.39-17.el9.x86_64.rpm
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-231.el9_7.10.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 608227
-    checksum: sha256:d473bf62eafab2e29a85e7bea9c71992441b71e37a2345a4b6e37d27689bc5a0
-    name: file-libs
-    evr: 5.39-17.el9
-    sourcerpm: file-5.39-17.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-270.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 2084453
-    checksum: sha256:39e15c1eb3181970e467e4baeaf31673120890b7bb9dd97b311f1c1128b76d16
-    name: glibc
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-270.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 322519
-    checksum: sha256:f63ee066c0942641ea683e499087a0e9b4fa80645387871ebef264bd51640567
-    name: glibc-common
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-270.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1765629
-    checksum: sha256:8efaf43e7d522733399caa5df7cdaca13a3549c56ea918053b11fb3d898c0bab
+    size: 1765503
+    checksum: sha256:17c997f5c4f492905f20196848d3dbee3ff46ce02033992465d750d2ecede7c8
     name: glibc-gconv-extra
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-270.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 685314
-    checksum: sha256:a6ed1995b04ec6c750b5467e7fe085acca53d63f8ec27dd768de1eb50b9a1dc1
-    name: glibc-langpack-en
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-270.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 31845
-    checksum: sha256:1ea08534d2eafe91a9d549277ab1682913f0407c1c4e3e0d89626975aca35fc8
-    name: glibc-minimal-langpack
-    evr: 2.34-270.el9_8
-    sourcerpm: glibc-2.34-270.el9_8.src.rpm
+    evr: 2.34-231.el9_7.10
+    sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1133828
@@ -2034,6 +9921,13 @@ arches:
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 49137
+    checksum: sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 166025
@@ -2041,6 +9935,13 @@ arches:
     name: less
     evr: 590-6.el9
     sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libatomic-11.5.0-11.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 23219
+    checksum: sha256:557a5080f5f974b09e24acd6c182ef24d43b9707ea7bb383dcf2bfe939347ff8
+    name: libatomic
+    evr: 11.5.0-11.el9
+    sourcerpm: gcc-11.5.0-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 60575
@@ -2048,13 +9949,13 @@ arches:
     name: libcbor
     evr: 0.7.0-5.el9
     sourcerpm: libcbor-0.7.0-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 112056
-    checksum: sha256:65a730688dfea27934b75af3acf30150c6d254c89d8b68b63233ae7f8b6c9b94
+    size: 109330
+    checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
     name: libedit
-    evr: 3.1-39.20210216cvs.el9
-    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 102746
@@ -2062,20 +9963,13 @@ arches:
     name: libfido2
     evr: 1.13.0-2.el9
     sourcerpm: libfido2-1.13.0-2.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 87280
-    checksum: sha256:77c66827ffc14df2f43612b26128b1fd58d5c9597d4d4e564aa239b161272872
-    name: libgcc
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 263723
-    checksum: sha256:87b9a7316760374111290e6e4c76ee4d093566f08a7c7c91ad7827c5948afb69
-    name: libgomp
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+    size: 52912
+    checksum: sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 38387
@@ -2083,13 +9977,13 @@ arches:
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 763021
-    checksum: sha256:513df35338962e053052b9d52429e8a5f3d60dfe6b1757cd9faaf61d6abda955
-    name: libstdc++
-    evr: 11.5.0-14.el9
-    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+    size: 198410
+    checksum: sha256:e5d79885864cd5b2a307065b43ba1af1523ec7ac26eace2717c70ede1b6e4c56
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 553896
@@ -2097,6 +9991,13 @@ arches:
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-9.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 1239738
+    checksum: sha256:e808c97dbacfb05e1d9096fb062e1851201307ac80b63f57b561c9234141f550
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-6.2-12.20210508.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 416252
@@ -2104,62 +10005,20 @@ arches:
     name: ncurses
     evr: 6.2-12.20210508.el9
     sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-8.7p1-48.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 97840
-    checksum: sha256:d62dfd41f9688efa2cf1ceedb96084c63e297fbdcfd1e72bc6757c730092b60c
-    name: ncurses-base
-    evr: 6.2-12.20210508.el9
-    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 336270
-    checksum: sha256:f3e1f8e59c7116278aa19b6705a1443f6307d4d6fbdde75a23d2f5d60636cb16
-    name: ncurses-libs
-    evr: 6.2-12.20210508.el9
-    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 442163
-    checksum: sha256:e699c3fd161d4741658320f10064bb82ab7530d07d3d34850142ccc102ce7c82
+    size: 475180
+    checksum: sha256:f9167df3110f931cded7e8500f501d1c0693bfbdc9cf92a77cde95f07a47f3c2
     name: openssh
-    evr: 9.9p1-7.el9_8
-    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-48.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 798466
-    checksum: sha256:5663973f870ce57e55bb94e94b84ff020d6b24cbaabdca9fed99665f6513c847
+    size: 735877
+    checksum: sha256:32685f9fc5a8b89d35da65d808f79530b49dba570ad2f3a5e26dba29324c9845
     name: openssh-clients
-    evr: 9.9p1-7.el9_8
-    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-4.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1564134
-    checksum: sha256:e0e2c1f901d3f6245ff43f194ac11ba133cf99c630307239722c07a2282a1356
-    name: openssl
-    evr: 1:3.5.5-4.el9_8
-    sourcerpm: openssl-3.5.5-4.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 14256
-    checksum: sha256:c00860e9c5a1d90488aa2eb65fe41f62926b38c6b3669d331a8b97e4a60223ac
-    name: openssl-fips-provider
-    evr: 3.0.7-11.el9_8
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 595008
-    checksum: sha256:60d36ad3a67d6b00e67bb0a19c0902fbb2ecdd873cf7f280a3039d04a092790c
-    name: openssl-fips-provider-so
-    evr: 3.0.7-11.el9_8
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-4.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 2426674
-    checksum: sha256:126c17e907e1f6cbbd3989a478e933a74d5508e70b8983b0f6a94e7fd2a903e6
-    name: openssl-libs
-    evr: 1:3.5.5-4.el9_8
-    sourcerpm: openssl-3.5.5-4.el9_8.src.rpm
+    evr: 8.7p1-48.el9_7
+    sourcerpm: openssh-8.7p1-48.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 45675
@@ -2181,6 +10040,20 @@ arches:
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 244557
+    checksum: sha256:fe02f46c19edea28a94b6b8756c25649631e6776d9c5597fe71c86b801f6ba2b
+    name: policycoreutils
+    evr: 3.6-3.el9
+    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 361526
+    checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 157800
@@ -2188,20 +10061,34 @@ arches:
     name: python3-pyparsing
     evr: 2.4.7-9.el9
     sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/unzip-6.0-60.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 185941
-    checksum: sha256:6a83acc410c8640daf3f97cd978cc9400ca9caf600006fd1510622bfa9faaf23
+    size: 623460
+    checksum: sha256:91946d729d2b03b4abe1c43962f22d110468db0163241cda7b1d549c615d0261
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 1152092
+    checksum: sha256:2062dce4bed26d3684de4dad68f32307ebacf5c7d50d3aa7bf6470e66fb36df5
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/unzip-6.0-59.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 186130
+    checksum: sha256:1142b2ba41dc0a6d919052337e6c82c07ee1021fa2ed93c7b5e87f986eef41d8
     name: unzip
-    evr: 6.0-60.el9
-    sourcerpm: unzip-6.0-60.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.5.noarch.rpm
+    evr: 6.0-59.el9
+    sourcerpm: unzip-6.0-59.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-23.el9_7.2.noarch.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 21544
-    checksum: sha256:9d003446811c32e02b50a11b6f1bfb237ab35a649ec685c1670e576e254036d5
+    size: 20860
+    checksum: sha256:e3fc2d706b1e395043a8a9bc76bb04c1ef7174269c840cb73176d00260df2724
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.5
-    sourcerpm: vim-8.2.2637-26.el9_8.5.src.rpm
+    evr: 2:8.2.2637-23.el9_7.2
+    sourcerpm: vim-8.2.2637-23.el9_7.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zip-3.0-35.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 276200


### PR DESCRIPTION
## Summary

- **Dockerfile.cli-stack.rh rework**: Move `chmod` to packager stage (`chmod -R a+rX`), switch final image from `ubi-minimal` to `ubi-micro`, copy `/licenses/` from component image instead of build context, remove old `chown`/`chmod` RUN layer, add `name` label
- **Multi-platform tuf-tool builds**: Switch Tekton tuf-tool pipelines (PR + push) from `docker-build-oci-ta` to `docker-build-multi-platform-oci-ta` with `build-platforms: [linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x]`, add `path-context` and `image-version` params
- **Dockerfile.rh multi-arch support**: Install `clang` conditionally on ppc64le/s390x, suppress s390x `string-compare` warning via `CFLAGS`
- **rpms multi-arch**: Update `rpms.in.yaml` to include `clang` and support `[x86_64, aarch64, ppc64le, s390x]` arches; update `rpms.lock.yaml` with full multi-arch dependency resolution

## Notes

- go-toolset digest (`e06a6f4c...`) is already a multi-arch manifest list -- no change needed
- cli-tuftool component digest (`af32938b...`) remains single-arch (amd64) as tuftool is currently linux/amd64 only
- cli-stack push pipeline does not need `prefetch-input` since it performs no builds (packaging only)

## Test plan

- [ ] Verify Tekton tuf-tool PR pipeline triggers multi-platform builds
- [ ] Verify cli-stack Dockerfile builds successfully with ubi-micro final image
- [ ] Verify clang installs correctly on ppc64le/s390x during tuf-tool builds
- [ ] Verify CFLAGS suppression works on s390x cargo builds